### PR TITLE
[코스] 완료 코스, 코스 목록 조회 API 수정

### DIFF
--- a/src/api/course.ts
+++ b/src/api/course.ts
@@ -1,16 +1,16 @@
 import express from "express";
 import courseService from "../service/courseService";
-// import auth from "../middleware/auth";
+import auth from "../middleware/auth";
 
 const router = express.Router();
 
-router.get("/:id", async(req, res) => {
-  const result = await courseService.library(req.params.id);
+router.get("/", auth, async(req, res) => {
+  const result = await courseService.library(req.body.user.id);
   res.status(result.status).json(result);
 });
 
-router.get("/complete/:id", async (req, res) => {
-  const result = await courseService.complete(req.params.id);
+router.get("/complete", auth, async (req, res) => {
+  const result = await courseService.complete(req.body.user.id);
   res.status(result.status).json(result);
 });
 

--- a/src/dto/Course/Complete/CompleteCourseResponseDTO.ts
+++ b/src/dto/Course/Complete/CompleteCourseResponseDTO.ts
@@ -12,7 +12,6 @@ export interface TotalCompleteCourseResponseDTO {
   situation: number;
   property: number;
   title: string;
-  description: string;
   totalDays: number;
   year: string;
   month: string;
@@ -24,9 +23,6 @@ export interface TotalCompleteChallengeResponseDTO {
   day: number;
   situation: number;
   title: string;
-  happy: number;
-  beforeMent: string;
-  afterMent: string;
   year: string;
   month: string;
   date: string;

--- a/src/service/courseService.ts
+++ b/src/service/courseService.ts
@@ -120,9 +120,6 @@ export default {
             day: challenge.getDay(),
             situation: 2,
             title: challenge.getTitle(),
-            happy: challenge.getHappy(),
-            beforeMent: challenge.getBeforeMent(),
-            afterMent: challenge.getAfterMent(),
             year: year,
             month: month,
             date: date
@@ -139,7 +136,6 @@ export default {
           situation: 2,
           property: course.getProperty(),
           title: course.getTitle(),
-          description: course.getDescription(),
           totalDays: course.getTotalDays(),
           year: year,
           month: month,

--- a/src/service/courseService.ts
+++ b/src/service/courseService.ts
@@ -9,10 +9,9 @@ import { CompleteCourse } from "../models/CompleteCourse";
 import { User } from "../models/User";
 
 export default {
-  library: async (id: String) => {
+  library: async (id: string) => {
     try {
-      const userId = Number(id);
-      const user = await User.findOne({ where: { id: userId } });
+      const user = await User.findOne({ where: { id: id } });
       if (!user) {
         return notExistUser;
       }
@@ -23,7 +22,7 @@ export default {
 
       const completeCourses = await CompleteCourse.findAll({
         attributes: ["course_id", "end_date"],
-        where: { user_id: userId },
+        where: { user_id: id },
       });
 
       let beforeCourses: SimpleCourseResponseDTO[] = [];
@@ -82,15 +81,14 @@ export default {
       return serverError;
     }
   },
-  complete: async (id: String) => {
+  complete: async (id: string) => {
     try {
-      let userId = Number(id);
-      const user = await User.findOne({ where: { id: userId } });
+      const user = await User.findOne({ where: { id: id } });
       if (!user) {
         return notExistUser;
       }
 
-      const completeCourses = await CompleteCourse.findAll({ where: { user_id: userId } });
+      const completeCourses = await CompleteCourse.findAll({ where: { user_id: id } });
       if (completeCourses.length == 0) {
         const notExistCompleteCourse: CompleteCourseResponseDTO = {
           status: 202,


### PR DESCRIPTION
- 완료 코스 조회 API response를 변경했습니다.
- 완료 코스 조회, 코스 목록 조회에서 id로 식별하던 것을 jwt로 식별하도록 변경했습니다.

## 완료한 코스 없을 때
![스크린샷 2021-09-10 오전 1 21 54](https://user-images.githubusercontent.com/49138331/132725196-c1b9e112-89f0-4779-9d7b-2bc8f8e6ebce.png)

## 완료 코스 있을 때
![스크린샷 2021-09-10 오전 1 25 19](https://user-images.githubusercontent.com/49138331/132725210-83fa4ff2-52f5-4151-b58c-c0456abdc10f.png)
