### PR TITLE
[코스] 코스 진행하기 API에 뱃지 로직 추가

### DIFF
--- a/src/class/Badge.ts
+++ b/src/class/Badge.ts
@@ -1,5 +1,5 @@
 /* 뱃지 클래스 */
-class Badge {
+export class Badge {
   // 아이디, 이름, 획득방법, AWS S3 이미지 URL
   private id: number;
   private name: string;

--- a/src/class/Level.ts
+++ b/src/class/Level.ts
@@ -1,4 +1,4 @@
-class Level {
+export class Level {
   private level: number;
   private fullHappy: number;
   private characterType?: number;

--- a/src/service/courseService.ts
+++ b/src/service/courseService.ts
@@ -3,6 +3,7 @@ import CompleteCourseResponseDTO, { TotalCompleteChallengeResponseDTO, TotalComp
 import CourseLibraryResponseDTO, { SimpleCourseResponseDTO } from '../dto/Course/Library/CourseLibraryResponseDTO';
 import StartCourseResponseDTO, { StartChallengeDetailResponseDTO, StartCourseDetailResponseDTO } from '../dto/Course/Start/StartCourseResponseDTO';
 import { courses } from '../dummy/Course';
+import { challengeBadges } from '../dummy/Badge';
 import { notExistCourseId, notExistUser } from "../errors";
 import { getDay, getMonth, getYear } from '../formatter/mohaengDateFormatter';
 import { IFail } from "../interfaces/IFail";
@@ -166,7 +167,7 @@ export default {
   start: async (id: string, courseId: string) => {
     try {
       let user = await User.findOne({
-        attributes: ['nickname', 'current_course_id', 'current_challenge_id', 'is_completed'],
+        attributes: ['nickname', 'current_course_id', 'current_challenge_id', 'is_completed', 'challenge_success_count'],
         where: { id: id }
       });
 
@@ -227,8 +228,22 @@ export default {
       for (let i = 0; i < challenges.length; i++) {
         let situation = 0;
         let challenge = challenges[i];
+        let badgeName = "";
 
-        if (i == 0) situation = 1;
+        if (i == 0) {
+          situation = 1;
+
+          // 진행할 챌린지에 대해서 뱃지 조건
+          if (user.challenge_success_count + 1 == 3) {
+            badgeName = challengeBadges[0].getName();
+          } else if (user.challenge_success_count + 1 == 21) {
+            badgeName = challengeBadges[1].getName();
+          } else if (user.challenge_success_count + 1 == 49) {
+            badgeName = challengeBadges[2].getName();
+          }
+          console.log(badgeName);
+        }
+        
         startChallenges.push({
           day: challenge.getDay(),
           situation: situation,
@@ -239,7 +254,7 @@ export default {
           year: "",
           month: "",
           date: "",
-          badge: ""
+          badge: badgeName
         });
       }
 


### PR DESCRIPTION
## 챌린지 수행 3개 -> 챌린지 한걸음 뱃지
![스크린샷 2021-09-14 오후 8 55 39](https://user-images.githubusercontent.com/49138331/133253527-a2e8c5b6-25a5-429b-840b-886857ba6364.png)

## 챌린지 수행 21개 -> 성장한 챌린지 뱃지
![스크린샷 2021-09-14 오후 8 54 15](https://user-images.githubusercontent.com/49138331/133253539-f2d02014-5869-4632-86a8-fc2ccf205824.png)

## 챌린지 수행 49개 -> 챌린지 챔피언 뱃지
![스크린샷 2021-09-14 오후 8 55 19](https://user-images.githubusercontent.com/49138331/133253562-b630f83c-8a8d-4a40-807b-059f9e8f7b46.png)
