### PR TITLE
[회원가입] 회원가입 시 버그 수정

### DIFF
--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -75,7 +75,6 @@ User.init(
     },
     token: {
       type: DataTypes.STRING(100),
-      unique: true,
     },
     email: {
       type: DataTypes.STRING(30),


### PR DESCRIPTION
## 회원가입 버그 수정
token 필드에 unique 제약 조건을 걸었었는데 회원가입할 때 토큰을 안받기로 했었잖아요..?
token이 null인 필드가 또 들어가려고 했어서 오류가 발생했었습니다... 일단 unique 제약 조건 없애줬어요!

## 테스팅 결과
![image](https://user-images.githubusercontent.com/71828832/133299367-aeb3ff1c-0995-4a8a-8f7e-a0d16b4d07d3.png)
