### PR TITLE
[코스] 코스 라이브러리 조회 API 수정

### DIFF
--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,7 +1,7 @@
 import { Sequelize } from 'sequelize';
 import config from '../config/config';
 
-const sequelzie = new Sequelize(
+const sequelize = new Sequelize(
   config.development.database,
   config.development.username,
   config.development.password,
@@ -12,4 +12,4 @@ const sequelzie = new Sequelize(
   }
 );
 
-export default sequelzie;
+export default sequelize;

--- a/src/service/courseService.ts
+++ b/src/service/courseService.ts
@@ -22,12 +22,13 @@ export default {
       }
 
       const currentCourseId = user.current_course_id;
-      console.log("현재 진행 중인 코스 아이디: " + currentCourseId);
       const isProgress = currentCourseId != null ? true : false;
 
       const completeCourses = await CompleteCourse.findAll({
-        attributes: ["course_id", "end_date"],
+        attributes: ["course_id"],
+        group: ["user_id", "course_id"],
         where: { user_id: id },
+        order: ["course_id"]
       });
 
       let beforeCourses: SimpleCourseResponseDTO[] = [];
@@ -35,20 +36,22 @@ export default {
 
       for (let i = 0; i < courses.length; ++i) {
         let flag = false;
-        if ((i+1) == currentCourseId) {
+        if (isProgress && (i+1) == currentCourseId) {
           continue; // 현재 진행 중인 코스면 skip
         }
+
+        let course = courses[i];
         
         // 완료한 코스일 경우
         for (let j = 0; j < completeCourses.length; ++j) {
-          if (completeCourses[j].course_id == (i + 1)) {
+          if (completeCourses[j].course_id == course.getId()) {
             afterCourses.push({
-              id: courses[i+1].getId(),
+              id: course.getId(),
               situation: 2,
-              property: courses[i+1].getProperty(),
-              title: courses[i+1].getTitle(),
-              description: courses[i+1].getDescription(),
-              totalDays: courses[i+1].getTotalDays()
+              property: course.getProperty(),
+              title: course.getTitle(),
+              description: course.getDescription(),
+              totalDays: course.getTotalDays()
             });
             flag = true;
             break;
@@ -58,12 +61,12 @@ export default {
         // 진행 전인 코스일 경우
         if (!flag) {
           beforeCourses.push({
-            id: courses[i].getId(),
+            id: course.getId(),
             situation: 0,
-            property: courses[i].getProperty(),
-            title: courses[i].getTitle(),
-            description: courses[i].getDescription(),
-            totalDays: courses[i].getTotalDays()
+            property: course.getProperty(),
+            title: course.getTitle(),
+            description: course.getDescription(),
+            totalDays: course.getTotalDays()
           });
         }
       }


### PR DESCRIPTION
## 완료 코스가 중복될 때 (다시하기)
![스크린샷 2021-09-19 오후 8 58 26](https://user-images.githubusercontent.com/49138331/133926728-46abeed2-ea6a-4fcf-913c-9e4fceb51de1.png)

## 진행 전 코스 먼저, 완료 코스는 중복 없이
![스크린샷 2021-09-19 오후 8 58 39](https://user-images.githubusercontent.com/49138331/133926736-61410a3f-1b79-4515-8f06-c716f87a1da5.png)
![스크린샷 2021-09-19 오후 8 58 44](https://user-images.githubusercontent.com/49138331/133926739-ac32ed87-7164-4336-b08a-acdcef9065b0.png)
> 코스 id로 정렬했는데, 가나다 순이라고 해서 더미에 가나다순으로 코스를 넣어놓으면 될 것 같음
