### PR TITLE
[챌린지] 챌린지 인증하기 API

### DIFF
--- a/src/api/challenge.ts
+++ b/src/api/challenge.ts
@@ -1,11 +1,17 @@
 import express from "express";
 import auth from "../middleware/auth";
 import challengeService from '../service/challengeService';
+import courseService from '../service/courseService';
 
 const router = express.Router();
 
 router.get("/", auth, async (req, res) => {
   const result = await challengeService.today(req.body.user.id);
+  res.status(result.status).json(result);
+});
+
+router.put("/:courseId/:challengeId", auth, async (req, res) => {
+  const result = await challengeService.certification(req.body.user.id, req.params.courseId, req.params.challengeId);
   res.status(result.status).json(result);
 });
 

--- a/src/dto/Challenge/Certification/CertificationChallengeResponseDTO.ts
+++ b/src/dto/Challenge/Certification/CertificationChallengeResponseDTO.ts
@@ -1,0 +1,30 @@
+export default interface CertificationChallengeResponseDTO {
+  status: number;
+  data: CertificationDetailResponseDTO;
+}
+
+export interface CertificationDetailResponseDTO {
+  characterImg: string;
+  challengeCompletion: CertificationChallengeCompletionResponseDTO;
+  courseCompletion: CertificationCourseCompletionResponseDTO;
+  levelUp: CertificationLevelUpResponseDTO;
+}
+
+export interface CertificationChallengeCompletionResponseDTO {
+  happy: number;
+  fullHappy: number;
+  userHappy: number;
+  isPenalty: boolean;
+}
+
+export interface CertificationCourseCompletionResponseDTO {
+  property?: number;
+  title?: string;
+  happy?: number;
+  userHappy?: number;
+}
+
+export interface CertificationLevelUpResponseDTO {
+  level?: number;
+  styleImg?: string;
+}

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -51,15 +51,29 @@ export const notMatchSignIn: IFail = {
   message: "이메일 계정 또는 비밀번호를 확인해주세요",
 };
 
+export const invalidCourseChallengeId: IFail = {
+  status: 400,
+  message: "현재 진행 중인 코스 또는 챌린지가 아닙니다."
+};
+
 export const notExistCourseId: IFail = {
   status: 404,
   message: "해당 id의 코스가 존재하지 않습니다."
 }
 
+export const notExistChallengeId: IFail = {
+  status: 404,
+  message: "해당 id의 챌린지가 존재하지 않습니다."
+};
 
 export const notExistProgressCourse: IFail = {
   status: 404,
   message: "진행 중인 코스가 없습니다."
+};
+
+export const alreadyCompleteChallenge: IFail = {
+  status: 409,
+  message: "이미 인증이 완료되었습니다."
 };
 
 export const notExistFeedContent: IFail = {

--- a/src/models/CompleteChallenge.ts
+++ b/src/models/CompleteChallenge.ts
@@ -6,7 +6,7 @@ interface CompleteChallengeAttributes {
   user_id: number;
   course_id: number;
   challenge_id: number;
-  date: Date;
+  date?: Date;
 };
 
 export class CompleteChallenge extends Model<CompleteChallengeAttributes>{
@@ -40,6 +40,8 @@ CompleteChallenge.init(
     },
     date: {
       type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
     }
   },
   {

--- a/src/service/challengeService.ts
+++ b/src/service/challengeService.ts
@@ -266,71 +266,70 @@ export default {
       const today = new Date(); // 오늘
       let recentChallengeDate = new Date(); // DB에 저장된 최근 챌린지 완료 날짜 다음날
       recentChallengeDate = new Date(recentChallengeDate.setDate(user.recent_challenge_date.getDate() + 1));
+      // 챌린지 연속 수행 여부
+      if (getYear(today) == getYear(recentChallengeDate) && getMonth(today) == getMonth(recentChallengeDate) && getDay(today) == getDay(recentChallengeDate)) { // 연속 수행에 성공한 경우
+        challengeSuccessCount++;
+      } else {
+        challengeSuccessCount = 1;
+      }
 
-      // 패널티가 없는 경우만 해피지수 & 코스 뱃지를 얻을 수 있음
+      // 코스 완료라면 코스 뱃지를 얻을 수 있음
+      if (completeCourse) {
+        let propertyCount = [0, 0, 0, 0, 0, 0, 0];
+        const completeCourses = await CompleteCourse.findAll({
+          where: { user_id: id }
+        });
+
+        // 유저가 완료한 코스 속성을 카운트
+        // 현재 속성이 2개라면 3개 완료했으니까, 뱃지 부여
+        for (let i = 0; i < completeCourses.length; i++) {
+          propertyCount[courses[completeCourses[i].course_id - 1].getProperty() - 1]++;
+        }
+        const currentProperty = course.getProperty();
+        if (propertyCount[currentProperty - 1] == 2) {  // 코스 뱃지를 얻을 수 있는 경우
+          isBadgeNew = true;  // 뱃지 부여 여부 true
+          Badge.create({
+            id: currentProperty,
+            user_id: id
+          });
+          badgeCount++; // 뱃지 개수 +1
+        }
+      }
+      
+      // 챌린지 수행 횟수 뱃지
+      // 받을 수 있다면, 뱃지 부여 여부 true & 뱃지 개수 +1
+      if (completeChallengeCount == 3) {
+        isBadgeNew = true;
+        // 챌린지 한걸음
+        Badge.create({
+          id: 8,
+          user_id: id
+        });
+        badgeCount++;
+      }
+      else if (completeChallengeCount == 21) {
+        isBadgeNew = true;
+        // 성장한 챌린저
+        Badge.create({
+          id: 9,
+          user_id: id
+        });
+        badgeCount++;
+      }
+      else if (completeChallengeCount == 49) {
+        isBadgeNew = true;
+        // 챌린지 챔피언
+        Badge.create({
+          id: 10,
+          user_id: id
+        });
+        badgeCount++;
+      }
+
+      // 패널티가 없는 경우만 해피지수를 얻을 수 있음
       if (!user.challenge_penalty) {
         userHappy += challenge.getHappy();  // 챌린지 해피지수
-
-        // 코스 완료라면 코스 뱃지를 얻을 수 있음
-        if (completeCourse) {
-          userHappy += course.getHappy(); // 코스 해피지수
-          let propertyCount = [0, 0, 0, 0, 0, 0, 0];
-          const completeCourses = await CompleteCourse.findAll({
-            where: { user_id: id }
-          });
-
-          // 유저가 완료한 코스 속성을 카운트
-          // 현재 속성이 2개라면 3개 완료했으니까, 뱃지 부여
-          for (let i = 0; i < completeCourses.length; i++) {
-            propertyCount[courses[completeCourses[i].course_id - 1].getProperty() - 1]++;
-          }
-          const currentProperty = course.getProperty();
-          if (propertyCount[currentProperty - 1] == 2) {  // 코스 뱃지를 얻을 수 있는 경우
-            isBadgeNew = true;  // 뱃지 부여 여부 true
-            Badge.create({
-              id: currentProperty,
-              user_id: id
-            });
-            badgeCount++; // 뱃지 개수 +1
-          }
-        }
-        
-        // 챌린지 수행 횟수 뱃지
-        // 받을 수 있다면, 뱃지 부여 여부 true & 뱃지 개수 +1
-        if (completeChallengeCount == 3) {
-          isBadgeNew = true;
-          // 챌린지 한걸음
-          Badge.create({
-            id: 8,
-            user_id: id
-          });
-          badgeCount++;
-        }
-        else if (completeChallengeCount == 21) {
-          isBadgeNew = true;
-          // 성장한 챌린저
-          Badge.create({
-            id: 9,
-            user_id: id
-          });
-          badgeCount++;
-        }
-        else if (completeChallengeCount == 49) {
-          isBadgeNew = true;
-          // 챌린지 챔피언
-          Badge.create({
-            id: 10,
-            user_id: id
-          });
-          badgeCount++;
-        }
-        
-        // 챌린지 연속 수행 여부
-        if (getYear(today) == getYear(recentChallengeDate) && getMonth(today) == getMonth(recentChallengeDate) && getDay(today) == getDay(recentChallengeDate)) { // 연속 수행에 성공한 경우
-          challengeSuccessCount++;
-        } else {
-          challengeSuccessCount = 1;
-        }
+        if (completeCourse) userHappy += course.getHappy(); // 코스 해피지수
 
         // 현재 affinity에 userHappy를 더하면 레벨이 올라가는지 확인
         // 레벨업시 캐릭터 카드 부여 처리

--- a/src/service/challengeService.ts
+++ b/src/service/challengeService.ts
@@ -1,12 +1,18 @@
 import { SERVER_ERROR_MESSAGE } from "../constant";
 import { courses } from '../dummy/Course';
 import { challengeBadges, challengeCountBadges } from '../dummy/Badge';
-import { notExistProgressCourse, notExistUser } from "../errors";
+import { levels } from '../dummy/Level';
+import { invalidCourseChallengeId, alreadyCompleteChallenge, notExistChallengeId, notExistCourseId, notExistProgressCourse, notExistUser } from "../errors";
 import { getDay, getMonth, getYear } from '../formatter/mohaengDateFormatter';
 import { IFail } from "../interfaces/IFail";
 import { User } from '../models/User';
 import { CompleteChallenge } from '../models/CompleteChallenge';
 import TodayChallengeResponseDTO, { TodayChallengeDetailResponseDTO, TodayCourseDetailResponseDTO } from '../dto/Challenge/Today/TodayChallengeResponseDTO';
+import CertificationChallengeResponseDTO, { CertificationChallengeCompletionResponseDTO, CertificationCourseCompletionResponseDTO, CertificationLevelUpResponseDTO } from '../dto/Challenge/Certification/CertificationChallengeResponseDTO';
+import { ProgressChallenge } from '../models/ProgressChallenge';
+import { BeforeChallenge } from '../models/BeforeChallenge';
+import { CompleteCourse } from '../models/CompleteCourse';
+import { Badge } from '../models/Badge';
 
 export default {
   today: async (id: string) => {
@@ -155,6 +161,240 @@ export default {
         }
       };
 
+      return responseDTO;
+    } catch (err) {
+      console.error(err.message);
+      const serverError: IFail = {
+        status: 500,
+        message: SERVER_ERROR_MESSAGE,
+      };
+      return serverError;
+    }
+  },
+  certification: async (id: string, courseId: string, challengeId: string) => {
+    try {
+      let user_id = Number(id);
+      let course_id = Number(courseId);
+      let challenge_id = Number(challengeId);
+
+      // 코스 아이디나 챌린지 아이디가 유효하지 않은 경우
+      if (courses.length < course_id) {
+        return notExistCourseId;
+      } else if (courses[course_id - 1].getChallenges().length < challenge_id) {
+        return notExistChallengeId;
+      }
+
+      // 유저 현재 해피지수, 레벨, 현재 코스 아이디, 현재 챌린지 아이디, 챌린지 완료 여부, 완료한 코스 개수, 완료한 챌린지 개수, 보유한 뱃지 개수
+      // 챌린지 패널티 여부, 최근 챌린지 완료 날짜, 챌린지 연속 수행 횟수
+      const user = await User.findOne({
+        attributes: ['affinity', 'level', 'current_course_id', 'current_challenge_id', 'is_completed', 'complete_course_count', 'complete_challenge_count', 'badge_count', 
+          'challenge_penalty', 'recent_challenge_date', 'challenge_success_count'],
+        where: { id: id }
+      });
+
+      // 유저가 없는 경우
+      if (!user) {
+        return notExistUser;
+      }
+      // 이미 유저가 챌린지를 인증한 경우
+      if (user.is_completed) {
+        return alreadyCompleteChallenge;
+      }
+      // 현재 진행 중인 코스나 챌린지가 아닐 때
+      if (user.current_course_id != course_id || user.current_challenge_id != challenge_id) {
+        return invalidCourseChallengeId;
+      }
+
+      const course = courses[course_id - 1];  // 현재 코스
+      const challenge = course.getChallenges()[challenge_id - 1]; // 현재 완료한 챌린지
+
+      let userHappy = user.affinity; // 유저에 업데이트될 해피지수
+      let userLevel = user.level; // 유저에 업데이트될 레벨
+      let levelUp = false;  // 레벨업 여부
+
+      let completeCourse = false; // 챌린지 인증 시 코스 완료 여부
+      let completeCourseCount = user.complete_course_count; // 완료한 코스 개수 -> 코스 완료라면 +1 처리
+      const completeChallengeCount = user.complete_challenge_count + 1; // 완료한 챌린지 개수 -> +1 처리
+      let challengeSuccessCount = user.challenge_success_count; // 챌린지 연속 수행 횟수
+
+      let isBadgeNew = false; // 뱃지 부여 여부
+      let badgeCount = user.badge_count;  // 유저가 소유한 뱃지 개수
+
+      // 코스 완료라면
+      if (course.getTotalDays() == challenge.getDay()) {
+        completeCourse = true;  // 코스 완료 여부 true
+        completeCourseCount++;  // 완료 코스 개수 +1
+      }
+
+      // 마지막 챌린지 성공이 아니라면 BeforeChallenge 에서 챌린지 삭제
+      // ProgressChallenge에 다음 챌린지 삽입
+      if (!completeCourse) {
+        BeforeChallenge.destroy({
+          where: { user_id: id }
+        });
+        ProgressChallenge.create({
+          user_id: user_id,
+          course_id: course_id,
+          challenge_id: challenge_id + 1
+        });
+      }
+      // 다음 챌린지가 마지막 챌린지가 아니라면 BeforeChallenge에 다다음 챌린지 삽입
+      if (course.getTotalDays() > challenge.getDay() + 1) {
+        BeforeChallenge.create({
+          user_id: user_id,
+          course_id: course_id,
+          challenge_id: challenge_id + 2
+        });
+      }
+
+      // 인증한 챌린지 삭제
+      ProgressChallenge.destroy({
+        where: {
+          user_id: id,
+          course_id: courseId,
+          challenge_id: challengeId
+        }
+      });
+      // 인증한 챌린지 완료한 챌린지에 삽입
+      CompleteChallenge.create({
+        user_id: Number(id),
+        course_id: Number(courseId),
+        challenge_id: Number(challengeId)
+      });
+
+      
+      const today = new Date(); // 오늘
+      let recentChallengeDate = new Date(); // DB에 저장된 최근 챌린지 완료 날짜 다음날
+      recentChallengeDate = new Date(recentChallengeDate.setDate(user.recent_challenge_date.getDate() + 1));
+
+      // 패널티가 없는 경우만 해피지수 & 코스 뱃지를 얻을 수 있음
+      if (!user.challenge_penalty) {
+        userHappy += challenge.getHappy();  // 챌린지 해피지수
+
+        // 코스 완료라면 코스 뱃지를 얻을 수 있음
+        if (completeCourse) {
+          userHappy += course.getHappy(); // 코스 해피지수
+          let propertyCount = [0, 0, 0, 0, 0, 0, 0];
+          const completeCourses = await CompleteCourse.findAll({
+            where: { user_id: id }
+          });
+
+          // 유저가 완료한 코스 속성을 카운트
+          // 현재 속성이 2개라면 3개 완료했으니까, 뱃지 부여
+          for (let i = 0; i < completeCourses.length; i++) {
+            propertyCount[courses[completeCourses[i].course_id - 1].getProperty() - 1]++;
+          }
+          const currentProperty = course.getProperty();
+          if (propertyCount[currentProperty - 1] == 2) {  // 코스 뱃지를 얻을 수 있는 경우
+            isBadgeNew = true;  // 뱃지 부여 여부 true
+            Badge.create({
+              id: currentProperty,
+              user_id: id
+            });
+            badgeCount++; // 뱃지 개수 +1
+          }
+        }
+        
+        // 챌린지 수행 횟수 뱃지
+        // 받을 수 있다면, 뱃지 부여 여부 true & 뱃지 개수 +1
+        if (completeChallengeCount == 3) {
+          isBadgeNew = true;
+          // 챌린지 한걸음
+          Badge.create({
+            id: 8,
+            user_id: id
+          });
+          badgeCount++;
+        }
+        else if (completeChallengeCount == 21) {
+          isBadgeNew = true;
+          // 성장한 챌린저
+          Badge.create({
+            id: 9,
+            user_id: id
+          });
+          badgeCount++;
+        }
+        else if (completeChallengeCount == 49) {
+          isBadgeNew = true;
+          // 챌린지 챔피언
+          Badge.create({
+            id: 10,
+            user_id: id
+          });
+          badgeCount++;
+        }
+        
+        // 챌린지 연속 수행 여부
+        if (getYear(today) == getYear(recentChallengeDate) && getMonth(today) == getMonth(recentChallengeDate) && getDay(today) == getDay(recentChallengeDate)) { // 연속 수행에 성공한 경우
+          challengeSuccessCount++;
+        } else {
+          challengeSuccessCount = 1;
+        }
+
+        // 현재 affinity에 userHappy를 더하면 레벨이 올라가는지 확인
+        // 레벨업시 캐릭터 카드 부여 처리
+        if (userHappy > levels[userLevel - 1].getFullHappy()) {
+          levelUp = true;
+          userHappy -= levels[userLevel - 1].getFullHappy();
+          userLevel++;
+        }
+      }
+
+      // 유저 정보 업데이트
+      User.update(
+        {
+          affinity: userHappy,
+          level: userLevel,
+          is_completed: true,
+          complete_course_count: completeCourseCount,
+          complete_challenge_count: completeChallengeCount,
+          badge_count: badgeCount,
+          challenge_penalty: false,
+          is_badge_new: isBadgeNew,
+          is_style_new: levelUp,
+          recent_challenge_date: today,
+          challenge_success_count: challengeSuccessCount
+        },
+        { where: {id: id} }
+      );
+      
+      // 챌린지는 항상 완료됨
+      let challengeCompletionDTO: CertificationChallengeCompletionResponseDTO = {
+        happy: challenge.getHappy(),
+        fullHappy: levels[userLevel - 1].getFullHappy(),
+        userHappy: userHappy,
+        isPenalty: user.challenge_penalty
+      };
+      let courseCompletionDTO: CertificationCourseCompletionResponseDTO = {};
+      let levelUpDTO: CertificationLevelUpResponseDTO = {};
+
+      // 코스를 완료했다면
+      if (completeCourse) {
+        courseCompletionDTO = {
+          property: course.getProperty(),
+          title: course.getTitle(),
+          happy: course.getHappy(),
+          userHappy: userHappy
+        };
+      }
+      // 레벨업을 했다면
+      if (levelUp) {
+        levelUpDTO = {
+          level: userLevel,
+          styleImg: ""
+        };
+      }
+
+      const responseDTO: CertificationChallengeResponseDTO = {
+        status: 200,
+        data: {
+          characterImg: "",
+          challengeCompletion: challengeCompletionDTO,
+          courseCompletion: courseCompletionDTO,
+          levelUp: levelUpDTO
+        }
+      };
       return responseDTO;
     } catch (err) {
       console.error(err.message);


### PR DESCRIPTION
## 확인한 사항
- 코스 또는 챌린지 아이디가 현재 진행하는 것이 아닐 경우
- 이미 인증한 경우
- 챌린지 패널티를 갖고 있을 경우
- 해피지수만 얻는 경우
- 마지막 챌린지를 완료해서 코스가 완료되었을 경우 뱃지 + 해피지수 부여
- 챌린지 횟수가 조건에 충족할 경우 뱃지 부여
- 여러 뱃지를 얻을 수도 있음
- 해피 지수를 모두 받아서 레벨업한 경우 캐릭터 스타일 부여
- 챌린지 연속 수행 여부  
- 패널티 적용 이후는 true

## DB
### 코스 완료인 경우
- 완료 코스 개수 +1
- 해피지수 부여
### 뱃지를 받을 경우
- 뱃지를 받을 때마다 badge_count + 1
- 뱃지 테이블에 해당 뱃지의 id, 유저 id 저장
- is_badge_new true로 설정
### 레벨업한 경우
- 해피지수와 레벨 계산함
- is_style_new true로 설정
### 패널티인 경우
- 해피 지수를 안줌.
- 레벨업 불가능
- 스타일을 얻을 수 없음
- 뱃지만 얻을 수 있음

---

## 코스 또는 챌린지 아이디가 현재 진행 중이 아닌 경우
![스크린샷 2021-09-23 오후 8 41 21](https://user-images.githubusercontent.com/49138331/134505920-c4253e2b-57c9-42cf-8b63-44d2555fb267.png)

## 이미 인증했을 경우
![스크린샷 2021-09-23 오후 8 39 28](https://user-images.githubusercontent.com/49138331/134505973-31ac58d1-dbec-4ac3-abbd-b7eb1a4bf92a.png)

## 챌린지 완료 (해피지수만 얻음)
![스크린샷 2021-09-23 오후 8 25 19](https://user-images.githubusercontent.com/49138331/134506023-869d03ee-1f5d-4af3-b4d9-5f2a7d1979d3.png)

## 해피지수를 얻어서 레벨업
![스크린샷 2021-09-23 오후 8 39 06](https://user-images.githubusercontent.com/49138331/134506053-041386e6-34a4-41a5-b85f-6a77292bfd5f.png)

## 마지막 챌린지를 인증해서 코스 완료
![스크린샷 2021-09-23 오후 8 41 30](https://user-images.githubusercontent.com/49138331/134506095-6ebda16e-1570-48bf-80df-7a3a6606c82d.png)

## 패널티가 있어서 해피지수는 받지 못하고 뱃지만 얻음 (원래 레벨업 가능인데 못함)
![스크린샷 2021-09-23 오후 9 37 45](https://user-images.githubusercontent.com/49138331/134507945-4694af26-77c2-446a-81a8-0e43cacce14d.png)


