### PR TITLE
[코스] 완료 코스 조회 id 중복 이슈 해결

### DIFF
--- a/src/service/courseService.ts
+++ b/src/service/courseService.ts
@@ -108,6 +108,7 @@ export default {
       }
 
       let responseCourses: TotalCompleteCourseResponseDTO[] = [];
+      let responseId = 1;
 
       for (let i = 0; i < completeCourses.length; ++i) {
         let responseChallenges: TotalCompleteChallengeResponseDTO[] = [];
@@ -138,7 +139,7 @@ export default {
         const month = getMonth(completeDate);
         const date = getDay(completeDate);
         responseCourses.push({
-          id: course.getId(),
+          id: responseId++,
           situation: 2,
           property: course.getProperty(),
           title: course.getTitle(),


### PR DESCRIPTION
> 완료 코스가 중복이 가능해서, response id가 중복되어서 따로 변수 생성해서 처리했습니다.

## 중복된 코스여도 response id 값을 다르게 처리
<img width="570" alt="스크린샷 2021-09-24 오후 3 37 54" src="https://user-images.githubusercontent.com/49138331/134629623-df3f031f-3513-4cae-8503-d75685b4bdd2.png">
<img width="471" alt="스크린샷 2021-09-24 오후 3 38 15" src="https://user-images.githubusercontent.com/49138331/134629638-3756bb1b-8474-4c04-bef6-9d817e7ebe30.png">

