### PR TITLE
[코스] 코스 진행하기 버그 해결

### DIFF
--- a/src/dto/Course/Start/StartCourseResponseDTO.ts
+++ b/src/dto/Course/Start/StartCourseResponseDTO.ts
@@ -34,5 +34,5 @@ export interface StartChallengeDetailResponseDTO {
   year: string;
   month: string;
   date: string;
-  badge: string;
+  badges: string[];
 }

--- a/src/service/courseService.ts
+++ b/src/service/courseService.ts
@@ -3,7 +3,7 @@ import CompleteCourseResponseDTO, { TotalCompleteChallengeResponseDTO, TotalComp
 import CourseLibraryResponseDTO, { SimpleCourseResponseDTO } from '../dto/Course/Library/CourseLibraryResponseDTO';
 import StartCourseResponseDTO, { StartChallengeDetailResponseDTO, StartCourseDetailResponseDTO } from '../dto/Course/Start/StartCourseResponseDTO';
 import { courses } from '../dummy/Course';
-import { challengeBadges } from '../dummy/Badge';
+import { challengeBadges, challengeCountBadges } from '../dummy/Badge';
 import { notExistCourseId, notExistUser } from "../errors";
 import { getDay, getMonth, getYear } from '../formatter/mohaengDateFormatter';
 import { IFail } from "../interfaces/IFail";
@@ -12,6 +12,7 @@ import { CompleteChallenge } from '../models/CompleteChallenge';
 import { CompleteCourse } from "../models/CompleteCourse";
 import { ProgressChallenge } from '../models/ProgressChallenge';
 import { User } from "../models/User";
+import { Badge } from "../models/Badge";
 
 export default {
   library: async (id: string) => {
@@ -170,7 +171,7 @@ export default {
   start: async (id: string, courseId: string) => {
     try {
       let user = await User.findOne({
-        attributes: ['nickname', 'current_course_id', 'current_challenge_id', 'is_completed', 'challenge_success_count'],
+        attributes: ['nickname', 'current_course_id', 'current_challenge_id', 'is_completed', 'complete_challenge_count', 'challenge_success_count'],
         where: { id: id }
       });
 
@@ -186,7 +187,7 @@ export default {
       let challenges = courses[cid].getChallenges();
       let isPenalty = false;
       // 코스 변경인 경우
-      if (challenges.length > user.current_challenge_id) {
+      if (user.current_course_id != null && user.current_challenge_id != null) {
         // 패널티 부여
         isPenalty = true;
         // 챌린지 삭제
@@ -230,20 +231,31 @@ export default {
       for (let i = 0; i < challenges.length; i++) {
         let situation = 0;
         let challenge = challenges[i];
-        let badgeName = "";
+        let badges: string[] = [];
 
         if (i == 0) {
           situation = 1;
 
           // 진행할 챌린지에 대해서 뱃지 조건
-          if (user.challenge_success_count + 1 == 3) {
-            badgeName = challengeBadges[0].getName();
-          } else if (user.challenge_success_count + 1 == 21) {
-            badgeName = challengeBadges[1].getName();
-          } else if (user.challenge_success_count + 1 == 49) {
-            badgeName = challengeBadges[2].getName();
+          if (user.complete_challenge_count + 1 == 3) {
+            badges.push(challengeBadges[0].getName());
+          } else if (user.complete_challenge_count + 1 == 21) {
+            badges.push(challengeBadges[1].getName());
+          } else if (user.complete_challenge_count + 1 == 49) {
+            badges.push(challengeBadges[2].getName());
           }
-          console.log(badgeName);
+
+          // 챌린지 연속 21일 수행
+          if (user.challenge_success_count + 1 == 21) {
+            // 뱃지를 소유하고있지 않을 경우에만 부여
+            const badge = await Badge.findAll({
+              where: {
+                id: challengeCountBadges[0].getId(),
+                user_id: id
+              }
+            });
+            if (!badge) badges.push(challengeCountBadges[0].getName());
+          }
         }
         
         startChallenges.push({
@@ -256,7 +268,7 @@ export default {
           year: "",
           month: "",
           date: "",
-          badge: badgeName
+          badges: badges
         });
       }
 

--- a/src/service/courseService.ts
+++ b/src/service/courseService.ts
@@ -257,14 +257,14 @@ export default {
             if (!badge) badges.push(challengeCountBadges[0].getName());
           }
         }
-        
+        // 챌린지 멘트 부분에 ㅁㅁㅁ 부분에 유저 닉네임 적용
         startChallenges.push({
           day: challenge.getDay(),
           situation: situation,
           title: challenge.getTitle(),
           happy: challenge.getHappy(),
-          beforeMent: challenge.getBeforeMent(),
-          afterMent: challenge.getAfterMent(),
+          beforeMent: challenge.getBeforeMent().replace(/ㅁㅁㅁ/gi, user.nickname),
+          afterMent: challenge.getAfterMent().replace(/ㅁㅁㅁ/gi, user.nickname),
           year: "",
           month: "",
           date: "",


### PR DESCRIPTION
## 수정사항
- 코스 변경 시에 분기 처리 조건 변경
- 챌린지 성공 개수에 따른 뱃지에 User 필드가 다른 것으로 쓰여서 변경
- 챌린지 수행 시 뱃지를 여러개 받을 수도 있어서 badgeName에서 badges로 배열 전달
- 챌린지 연속 수행의 경우 중복으로 뱃지를 줄 수도 있어서 중복 확인 부분 추가
- 챌린지 멘트에 유저 닉네임 적용하는 부분 추가

## 코스 변경인 경우
<img width="847" alt="스크린샷 2021-09-24 오후 4 32 26" src="https://user-images.githubusercontent.com/49138331/134637588-8e11e93d-82e7-4ef6-83af-b5019bfabb58.png">
<img width="781" alt="스크린샷 2021-09-24 오후 4 32 31" src="https://user-images.githubusercontent.com/49138331/134637612-943f8298-3ef6-49b6-9699-5bbdb59ae571.png">

## 뱃지 여러개 부여 가능
<img width="820" alt="스크린샷 2021-09-24 오후 4 34 14" src="https://user-images.githubusercontent.com/49138331/134637701-802d3f16-e3e5-42a3-81ef-8ab72876c414.png">
<img width="867" alt="스크린샷 2021-09-24 오후 4 34 19" src="https://user-images.githubusercontent.com/49138331/134637716-cdc625aa-b672-48bf-9d67-8fed92781346.png">

## 이미 연속 수행 뱃지가 있는 경우는 중복 수여 불가능
<img width="813" alt="스크린샷 2021-09-24 오후 4 40 31" src="https://user-images.githubusercontent.com/49138331/134637742-abdbfde7-34c2-4085-86ce-1c4dc9078817.png">
