### PR TITLE
[챌린지] 챌린지 진행하기 버그 수정

### DIFF
--- a/src/dto/Challenge/Certification/CertificationChallengeResponseDTO.ts
+++ b/src/dto/Challenge/Certification/CertificationChallengeResponseDTO.ts
@@ -11,10 +11,10 @@ export interface CertificationDetailResponseDTO {
 }
 
 export interface CertificationChallengeCompletionResponseDTO {
-  happy: number;
-  fullHappy: number;
-  userHappy: number;
-  isPenalty: boolean;
+  happy?: number;
+  userHappy?: number;
+  fullHappy?: number;
+  isPenalty?: boolean;
 }
 
 export interface CertificationCourseCompletionResponseDTO {
@@ -22,6 +22,7 @@ export interface CertificationCourseCompletionResponseDTO {
   title?: string;
   happy?: number;
   userHappy?: number;
+  fullHappy?: number;
 }
 
 export interface CertificationLevelUpResponseDTO {

--- a/src/service/challengeService.ts
+++ b/src/service/challengeService.ts
@@ -326,6 +326,25 @@ export default {
         badgeCount++;
       }
 
+      // 챌린지 연속 수행 뱃지
+      if (challengeSuccessCount == 21) {
+        // 뱃지를 소유하고있지 않을 경우에만 부여
+        const badge = await Badge.findAll({
+          where: {
+            id: challengeCountBadges[0].getId(),
+            user_id: id
+          }
+        });
+        if (badge.length == 0) {
+          isBadgeNew = true;
+          Badge.create({
+            id: challengeCountBadges[0].getId(),
+            user_id: id
+          });
+          badgeCount++;
+        }
+      }
+
       // 패널티가 없는 경우만 해피지수를 얻을 수 있음
       if (!user.challenge_penalty) {
         userHappy += challenge.getHappy();  // 챌린지 해피지수


### PR DESCRIPTION
# 처리한 것
1. 기존에 있는 뱃지인지 확인 필요
2. 연속 수행 뱃지 부여 처리
3. 만렙 분기 처리
4. 인증 완료 시 current_progress_percent 조정
5. 코스 완료 responseDTO 에 fullHappy 추가
6. 단계별 해피지수 더해지는 과정 적용
7. 패널티가 있을 때, happy는 무조건 0

> DB 확인 완료

## 코스 완료 response에 fullHappy 추가
<img width="738" alt="스크린샷 2021-09-25 오후 5 17 17" src="https://user-images.githubusercontent.com/49138331/134764727-8725c5bd-c93b-4b18-a833-dd321d77a8b9.png">

## 패널티가 있을 때
<img width="478" alt="스크린샷 2021-09-25 오후 5 34 49" src="https://user-images.githubusercontent.com/49138331/134765183-3cc6a2de-f145-4909-9f17-2ac008c4dbaf.png">

## 만렙으로 레벨업한 경우
<img width="538" alt="스크린샷 2021-09-25 오후 6 17 29" src="https://user-images.githubusercontent.com/49138331/134766438-324ced60-8dd5-4dd4-9d3c-ef3a14aa7c46.png">


