### PR TITLE
[프로필] 달성한 뱃지 조회 API

### DIFF
--- a/apidoc/api_data.js
+++ b/apidoc/api_data.js
@@ -1,6 +1,89 @@
 define({ "api": [
   {
     "type": "put",
+    "url": "/api/badge",
+    "title": "달성한 뱃지 조회",
+    "version": "1.0.0",
+    "name": "getBadge",
+    "group": "뱃지",
+    "header": {
+      "examples": [
+        {
+          "title": "Header-Example:",
+          "content": "{\n \"Content-Type\": \"application/json\"\n \"Bearer\": \"jwt\"\n}",
+          "type": "json"
+        }
+      ]
+    },
+    "success": {
+      "fields": {
+        "Success 200": [
+          {
+            "group": "Success 200",
+            "type": "Object[]",
+            "optional": false,
+            "field": "badges",
+            "description": "<p>하단부터 Object 정보</p>"
+          },
+          {
+            "group": "Success 200",
+            "type": "number",
+            "optional": false,
+            "field": "id",
+            "description": ""
+          },
+          {
+            "group": "Success 200",
+            "type": "string",
+            "optional": false,
+            "field": "name",
+            "description": ""
+          },
+          {
+            "group": "Success 200",
+            "type": "string",
+            "optional": false,
+            "field": "info",
+            "description": ""
+          },
+          {
+            "group": "Success 200",
+            "type": "string",
+            "optional": false,
+            "field": "image",
+            "description": ""
+          },
+          {
+            "group": "Success 200",
+            "type": "boolean",
+            "optional": false,
+            "field": "hasBadge",
+            "description": ""
+          }
+        ]
+      },
+      "examples": [
+        {
+          "title": "Success-Response:",
+          "content": "200 OK 달성한 뱃지 조회 성공\n{\n \"status\": 200,\n \"badges\": [\n   {\n     \"id\": 1,\n     \"name\": \"내 건강 챙기미\",\n     \"info\": \"건강 코스 3개\",\n     \"image\": \"imageUrl\",\n     \"hasBadge\": false\n   },\n   {\n     \"id\": 2,\n     \"name\": \"아이마이미마인\",\n     \"info\": \"\",\n     \"image\": \"imageUrl\",\n     \"hasBadge\": true\n   },\n   {\n     \"id\": 3,\n     \"name\": \"바른생활 모범생\",\n     \"info\": \"생활습관 코스 3개\",\n     \"image\": \"imageUrl\",\n     \"hasBadge\": false\n   }\n  ...\n ]\n}",
+          "type": "json"
+        }
+      ]
+    },
+    "error": {
+      "examples": [
+        {
+          "title": "Error-Response:",
+          "content": "401 유효하지 않은 유저\n{\n \"status\": 401,\n \"message\": \"유저가 존재하지 않습니다.\"\n}\n\n500 서버 에러\n{\n \"status\": 500,\n \"message\": \"서버 에러입니다. 서버 파트에게 문의해주세요 *^^*\"\n}",
+          "type": "json"
+        }
+      ]
+    },
+    "filename": "src/api/docs/badge.ts",
+    "groupTitle": "뱃지"
+  },
+  {
+    "type": "put",
     "url": "/api/feed/emoji/:id",
     "title": "이모지 추가",
     "version": "1.0.0",

--- a/apidoc/api_data.json
+++ b/apidoc/api_data.json
@@ -1,6 +1,89 @@
 [
   {
     "type": "put",
+    "url": "/api/badge",
+    "title": "달성한 뱃지 조회",
+    "version": "1.0.0",
+    "name": "getBadge",
+    "group": "뱃지",
+    "header": {
+      "examples": [
+        {
+          "title": "Header-Example:",
+          "content": "{\n \"Content-Type\": \"application/json\"\n \"Bearer\": \"jwt\"\n}",
+          "type": "json"
+        }
+      ]
+    },
+    "success": {
+      "fields": {
+        "Success 200": [
+          {
+            "group": "Success 200",
+            "type": "Object[]",
+            "optional": false,
+            "field": "badges",
+            "description": "<p>하단부터 Object 정보</p>"
+          },
+          {
+            "group": "Success 200",
+            "type": "number",
+            "optional": false,
+            "field": "id",
+            "description": ""
+          },
+          {
+            "group": "Success 200",
+            "type": "string",
+            "optional": false,
+            "field": "name",
+            "description": ""
+          },
+          {
+            "group": "Success 200",
+            "type": "string",
+            "optional": false,
+            "field": "info",
+            "description": ""
+          },
+          {
+            "group": "Success 200",
+            "type": "string",
+            "optional": false,
+            "field": "image",
+            "description": ""
+          },
+          {
+            "group": "Success 200",
+            "type": "boolean",
+            "optional": false,
+            "field": "hasBadge",
+            "description": ""
+          }
+        ]
+      },
+      "examples": [
+        {
+          "title": "Success-Response:",
+          "content": "200 OK 달성한 뱃지 조회 성공\n{\n \"status\": 200,\n \"badges\": [\n   {\n     \"id\": 1,\n     \"name\": \"내 건강 챙기미\",\n     \"info\": \"건강 코스 3개\",\n     \"image\": \"imageUrl\",\n     \"hasBadge\": false\n   },\n   {\n     \"id\": 2,\n     \"name\": \"아이마이미마인\",\n     \"info\": \"\",\n     \"image\": \"imageUrl\",\n     \"hasBadge\": true\n   },\n   {\n     \"id\": 3,\n     \"name\": \"바른생활 모범생\",\n     \"info\": \"생활습관 코스 3개\",\n     \"image\": \"imageUrl\",\n     \"hasBadge\": false\n   }\n  ...\n ]\n}",
+          "type": "json"
+        }
+      ]
+    },
+    "error": {
+      "examples": [
+        {
+          "title": "Error-Response:",
+          "content": "401 유효하지 않은 유저\n{\n \"status\": 401,\n \"message\": \"유저가 존재하지 않습니다.\"\n}\n\n500 서버 에러\n{\n \"status\": 500,\n \"message\": \"서버 에러입니다. 서버 파트에게 문의해주세요 *^^*\"\n}",
+          "type": "json"
+        }
+      ]
+    },
+    "filename": "src/api/docs/badge.ts",
+    "groupTitle": "뱃지"
+  },
+  {
+    "type": "put",
     "url": "/api/feed/emoji/:id",
     "title": "이모지 추가",
     "version": "1.0.0",

--- a/apidoc/api_project.js
+++ b/apidoc/api_project.js
@@ -9,7 +9,7 @@ define({
   "apidoc": "0.3.0",
   "generator": {
     "name": "apidoc",
-    "time": "2021-09-30T04:10:36.445Z",
+    "time": "2021-09-30T11:55:12.737Z",
     "url": "https://apidocjs.com",
     "version": "0.29.0"
   }

--- a/apidoc/api_project.json
+++ b/apidoc/api_project.json
@@ -9,7 +9,7 @@
   "apidoc": "0.3.0",
   "generator": {
     "name": "apidoc",
-    "time": "2021-09-30T04:10:36.445Z",
+    "time": "2021-09-30T11:55:12.737Z",
     "url": "https://apidocjs.com",
     "version": "0.29.0"
   }

--- a/src/api/badge.ts
+++ b/src/api/badge.ts
@@ -1,0 +1,12 @@
+import express from "express";
+import badgeService from "../service/badgeService";
+import auth from "../middleware/auth";
+
+const router = express.Router();
+
+router.get("/", auth, async (req, res) => {
+  const result = await badgeService.badge(req.body.user.id);
+  res.status(result.status).json(result);
+})
+
+module.exports = router;

--- a/src/api/docs/badge.ts
+++ b/src/api/docs/badge.ts
@@ -1,0 +1,64 @@
+/**
+ * @api {put} /api/badge 달성한 뱃지 조회
+ * 
+ * @apiVersion 1.0.0
+ * @apiName getBadge
+ * @apiGroup 뱃지
+ * 
+ * @apiHeaderExample {json} Header-Example:
+ * {
+ *  "Content-Type": "application/json"
+ *  "Bearer": "jwt"
+ * }
+ *
+ * @apiSuccess {Object[]} badges
+ * 하단부터 Object 정보
+ * @apiSuccess {number} id
+ * @apiSuccess {string} name 
+ * @apiSuccess {string} info 
+ * @apiSuccess {string} image
+ * @apiSuccess {boolean} hasBadge  
+ * 
+ * @apiSuccessExample {json} Success-Response:
+ * 200 OK 달성한 뱃지 조회 성공
+ * {
+ *  "status": 200,
+ *  "badges": [
+ *    {
+ *      "id": 1,
+ *      "name": "내 건강 챙기미",
+ *      "info": "건강 코스 3개",
+ *      "image": "imageUrl",
+ *      "hasBadge": false
+ *    },
+ *    {
+ *      "id": 2,
+ *      "name": "아이마이미마인",
+ *      "info": "",
+ *      "image": "imageUrl",
+ *      "hasBadge": true
+ *    },
+ *    {
+ *      "id": 3,
+ *      "name": "바른생활 모범생",
+ *      "info": "생활습관 코스 3개",
+ *      "image": "imageUrl",
+ *      "hasBadge": false
+ *    }
+ *   ...
+ *  ]
+ * }
+ * 
+ * @apiErrorExample Error-Response:
+ * 401 유효하지 않은 유저
+ * {
+ *  "status": 401,
+ *  "message": "유저가 존재하지 않습니다."
+ * }
+ * 
+ * 500 서버 에러
+ * {
+ *  "status": 500,
+ *  "message": "서버 에러입니다. 서버 파트에게 문의해주세요 *^^*"
+ * }
+ */

--- a/src/api/profile.ts
+++ b/src/api/profile.ts
@@ -10,7 +10,7 @@ router.put("/", auth, async (req, res) => {
   const requestDTO: ChangeNicknameRequestDTO = {
     nickname: nickname
   };
-  const result = await profileService.changeNickname(req.body.user.id, requestDTO);
+  const result = await profileService.nickname(req.body.user.id, requestDTO);
   res.status(result.status).json(result);
 })
 

--- a/src/dto/Badge/getBadgeResponseDTO.ts
+++ b/src/dto/Badge/getBadgeResponseDTO.ts
@@ -1,0 +1,12 @@
+export interface GetBadgeResponseDTO {
+  status: number;
+  badges: BadgeResponseDTO[];
+}
+
+export interface BadgeResponseDTO {
+  id: number;
+  name: string;
+  info: string;
+  image: string;
+  hasBadge: boolean;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,7 @@ app.use("/api/courses", require("./api/course"));
 app.use("/api", require("./api/auth"));
 app.use("/api/today", require("./api/challenge"));
 app.use("/api/character", require("./api/character"));
+app.use("/api/badge", require("./api/badge"));
 
 // error handler
 app.use(function (err, req, res, next) {

--- a/src/service/badgeService.ts
+++ b/src/service/badgeService.ts
@@ -1,0 +1,80 @@
+import { User } from "../models/User";
+import { Badge } from "../models/Badge";
+import { notExistUser, serverError } from "../errors";
+import { courseBadges, challengeBadges, challengeCountBadges, feedBadges, stickerBadges } from "../dummy/Badge";
+import { BadgeResponseDTO, GetBadgeResponseDTO } from "../dto/Badge/getBadgeResponseDTO";
+
+export default {
+  badge: async (userId: string) => {
+    try {
+      const user = await User.findOne({ attributes: ['id'], where: { id: userId }});
+      if (!user) {
+        return notExistUser;
+      }
+      
+      //뱃지 하나로 합치기
+      const badges = courseBadges.concat(challengeBadges, challengeCountBadges, feedBadges, stickerBadges)
+
+      const badgeResponse: Array<BadgeResponseDTO> = new Array<BadgeResponseDTO>();
+      const userBadges = await Badge.findAll({ attributes: ["id"], where: { user_id: userId }});
+
+      //뱃지 id만 담는 배열
+      let badgeIdArray: Array<Number> = new Array<Number>();
+      userBadges.forEach(badge => {
+        badgeIdArray.push(badge.id);
+      });
+
+      if(!userBadges) {
+        badges.forEach(badge => {
+          let badgeInfo: BadgeResponseDTO = {
+            id: badge.getId(),
+            name: badge.getName(),
+            info: badge.getHowObtain(),
+            image: badge.getImageURL(),
+            hasBadge: false
+          }
+          badgeResponse.push(badgeInfo);
+        });
+      }
+
+      else {
+        badges.forEach(badge => {
+          if (badgeIdArray.includes(badge.getId())) {
+            let badgeInfo: BadgeResponseDTO = {
+              id: badge.getId(),
+              name: badge.getName(),
+              info: "",
+              image: badge.getImageURL(),
+              hasBadge: true
+            }
+            badgeResponse.push(badgeInfo);
+          }
+
+          else {
+            let badgeInfo: BadgeResponseDTO = {
+              id: badge.getId(),
+              name: badge.getName(),
+              info: badge.getHowObtain(),
+              image: badge.getImageURL(),
+              hasBadge: false
+            }
+            badgeResponse.push(badgeInfo);
+          }
+        });
+      }
+
+      User.update({ is_badge_new: false}, { where: { id: userId }});
+
+      const responseDTO: GetBadgeResponseDTO = {
+        status: 200,
+        badges: badgeResponse
+      }
+      return responseDTO;
+    }
+
+    catch (err) {
+      console.error(err);
+      return serverError;
+    }
+  }
+}

--- a/src/service/profileService.ts
+++ b/src/service/profileService.ts
@@ -4,10 +4,10 @@ import { ChangeNicknameResponseDTO } from "../dto/Profile/Nickname/response/Chan
 import { notExistUser, nicknameLengthCheck, sameNickname, alreadyExistNickname, serverError } from "../errors";
 
 export default {
-  changeNickname: async (id: string, dto: ChangeNicknameRequestDTO) => {
+  nickname: async (id: string, dto: ChangeNicknameRequestDTO) => {
     try{
       const { nickname } = dto;
-      const user = await User.findOne({ attributes: ['nickname'], where: {id: id} });
+      const user = await User.findOne({ attributes: ['nickname'], where: { id: id }});
       
       if (!user) {
         return notExistUser;
@@ -21,7 +21,7 @@ export default {
         return sameNickname;
       }
       
-      const hasNickname = await User.findOne({ attributes: ['nickname'], where: {nickname: nickname } });
+      const hasNickname = await User.findOne({ attributes: ['nickname'], where: { nickname: nickname } });
       if (hasNickname) {
         return alreadyExistNickname;
       }


### PR DESCRIPTION
## 달성한 뱃지 조회 API 
프로필에서는 달성한 뱃지 개수만 볼 수 있고 달성한 뱃지를 자세히 보려면 홈에서 이동을 해야하더라구요...?
그래서 뱃지 관련 코드를 프로필 파일에 안넣고 뱃지파일을 따로 만들었습니다!
캐릭터도 홈에서 이동해야 볼 수 있는데 파일 따로 있어서 뱃지도 그렇게 했습니다 ~

뱃지조회시 User 테이블의 is_badge_new false 처리 완료

## 테스트 결과
![image](https://user-images.githubusercontent.com/71828832/135451687-1044e2a8-1a20-4464-87f5-8869d84223b6.png)
![image](https://user-images.githubusercontent.com/71828832/135451710-01355131-deda-483f-8cc0-fa1049bd805c.png)
