### PR TITLE
[소셜로그인] 카카오 로그인

### DIFF
--- a/apidoc/api_data.js
+++ b/apidoc/api_data.js
@@ -1,5 +1,83 @@
 define({ "api": [
   {
+    "type": "post",
+    "url": "/api/nickname",
+    "title": "소셜로그인 회원가입",
+    "version": "1.0.0",
+    "name": "createUser",
+    "group": "로그인/회원가입",
+    "parameter": {
+      "examples": [
+        {
+          "title": "Request-Example:",
+          "content": "{\n \"nickname\": \"시원뿡\"\n}",
+          "type": "json"
+        }
+      ]
+    },
+    "success": {
+      "fields": {
+        "Success 200": [
+          {
+            "group": "Success 200",
+            "type": "string",
+            "optional": false,
+            "field": "jwt",
+            "description": ""
+          }
+        ]
+      },
+      "examples": [
+        {
+          "title": "Success-Response:",
+          "content": "200 OK\n{\n \"status\": 200,\n \"data\": {\n   \"jwt\": \"jwt 토큰\"\n }\n}",
+          "type": "json"
+        }
+      ]
+    },
+    "error": {
+      "examples": [
+        {
+          "title": "Error-Response:",
+          "content": "\n404 닉네임 글자 제한\n{\n \"status\": 404,\n \"message\": \"닉네임은 1-6글자 이내로 작성해주세요\"\n}\n\n404 닉네임 중복\n{\n \"status\": 404,\n \"message\": \"이미 사용 중인 닉네임입니다.\"\n}\n\n500 서버 에러\n{\n \"status\": 500,\n \"message\": \"서버 에러입니다. 서버 파트에게 문의해주세요 *^^*\"\n}",
+          "type": "json"
+        }
+      ]
+    },
+    "filename": "src/api/docs/auth.ts",
+    "groupTitle": "로그인/회원가입"
+  },
+  {
+    "type": "get",
+    "url": "/api/kakao",
+    "title": "카카오 로그인",
+    "version": "1.0.0",
+    "name": "kakaoLogin",
+    "group": "로그인/회원가입",
+    "success": {
+      "fields": {
+        "Success 200": [
+          {
+            "group": "Success 200",
+            "type": "String",
+            "optional": false,
+            "field": "message",
+            "description": ""
+          }
+        ]
+      },
+      "examples": [
+        {
+          "title": "Success-Response:",
+          "content": "200 OK\n{\n \"status\": 200,\n \"message\": \"토큰 인증을 완료하였습니다.\"\n}\n\n500 서버 에러\n{\n \"status\": 500,\n \"message\": \"서버 에러입니다. 서버 파트에게 문의해주세요 *^^*\"\n}",
+          "type": "json"
+        }
+      ]
+    },
+    "filename": "src/api/docs/auth.ts",
+    "groupTitle": "로그인/회원가입"
+  },
+  {
     "type": "put",
     "url": "/api/badge",
     "title": "달성한 뱃지 조회",

--- a/apidoc/api_data.json
+++ b/apidoc/api_data.json
@@ -1,5 +1,83 @@
 [
   {
+    "type": "post",
+    "url": "/api/nickname",
+    "title": "소셜로그인 회원가입",
+    "version": "1.0.0",
+    "name": "createUser",
+    "group": "로그인/회원가입",
+    "parameter": {
+      "examples": [
+        {
+          "title": "Request-Example:",
+          "content": "{\n \"nickname\": \"시원뿡\"\n}",
+          "type": "json"
+        }
+      ]
+    },
+    "success": {
+      "fields": {
+        "Success 200": [
+          {
+            "group": "Success 200",
+            "type": "string",
+            "optional": false,
+            "field": "jwt",
+            "description": ""
+          }
+        ]
+      },
+      "examples": [
+        {
+          "title": "Success-Response:",
+          "content": "200 OK\n{\n \"status\": 200,\n \"data\": {\n   \"jwt\": \"jwt 토큰\"\n }\n}",
+          "type": "json"
+        }
+      ]
+    },
+    "error": {
+      "examples": [
+        {
+          "title": "Error-Response:",
+          "content": "\n404 닉네임 글자 제한\n{\n \"status\": 404,\n \"message\": \"닉네임은 1-6글자 이내로 작성해주세요\"\n}\n\n404 닉네임 중복\n{\n \"status\": 404,\n \"message\": \"이미 사용 중인 닉네임입니다.\"\n}\n\n500 서버 에러\n{\n \"status\": 500,\n \"message\": \"서버 에러입니다. 서버 파트에게 문의해주세요 *^^*\"\n}",
+          "type": "json"
+        }
+      ]
+    },
+    "filename": "src/api/docs/auth.ts",
+    "groupTitle": "로그인/회원가입"
+  },
+  {
+    "type": "get",
+    "url": "/api/kakao",
+    "title": "카카오 로그인",
+    "version": "1.0.0",
+    "name": "kakaoLogin",
+    "group": "로그인/회원가입",
+    "success": {
+      "fields": {
+        "Success 200": [
+          {
+            "group": "Success 200",
+            "type": "String",
+            "optional": false,
+            "field": "message",
+            "description": ""
+          }
+        ]
+      },
+      "examples": [
+        {
+          "title": "Success-Response:",
+          "content": "200 OK\n{\n \"status\": 200,\n \"message\": \"토큰 인증을 완료하였습니다.\"\n}\n\n500 서버 에러\n{\n \"status\": 500,\n \"message\": \"서버 에러입니다. 서버 파트에게 문의해주세요 *^^*\"\n}",
+          "type": "json"
+        }
+      ]
+    },
+    "filename": "src/api/docs/auth.ts",
+    "groupTitle": "로그인/회원가입"
+  },
+  {
     "type": "put",
     "url": "/api/badge",
     "title": "달성한 뱃지 조회",

--- a/apidoc/api_project.js
+++ b/apidoc/api_project.js
@@ -9,7 +9,7 @@ define({
   "apidoc": "0.3.0",
   "generator": {
     "name": "apidoc",
-    "time": "2021-09-30T11:55:12.737Z",
+    "time": "2021-10-06T12:40:28.702Z",
     "url": "https://apidocjs.com",
     "version": "0.29.0"
   }

--- a/apidoc/api_project.json
+++ b/apidoc/api_project.json
@@ -9,7 +9,7 @@
   "apidoc": "0.3.0",
   "generator": {
     "name": "apidoc",
-    "time": "2021-09-30T11:55:12.737Z",
+    "time": "2021-10-06T12:40:28.702Z",
     "url": "https://apidocjs.com",
     "version": "0.29.0"
   }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "apidoc": "^0.29.0",
     "arg": "^4.1.3",
     "aws-sdk": "^2.987.0",
+    "axios": "^0.22.0",
     "bcryptjs": "^2.4.3",
     "create-require": "^1.1.1",
     "dayjs": "^1.10.7",
@@ -46,6 +47,7 @@
     "mysql2": "^2.3.0",
     "node-schedule": "^2.0.0",
     "nodemon": "^2.0.12",
+    "qs": "^6.10.1",
     "sequelize": "^6.6.5",
     "sequelize-cli": "^6.2.0",
     "yn": "^3.1.1"

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -96,7 +96,6 @@ router.get("/kakao/callback", async (req, res) => {
   res.status(result.status).json(result);
 })
 
-
 router.post("/nickname", async (req, res) => {
   try{
     const nickname = req.body.nickname;

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,9 +1,14 @@
 import express from "express";
+import axios from "axios";
+import qs from "qs";
 import { check, validationResult } from "express-validator";
+import config from "../config";
 import { SignUpRequestDTO } from "../dto/Auth/SignUp/request/SignUpRequestDTO";
 import { SignInRequestDTO } from "../dto/Auth/SignIn/request/SignInRequestDTO";
+import { KakaoRequestDTO } from "../dto/Auth/Kakao/request/KakaoRequestDTO";
 import authService from "../service/authService";
 import verifyFCM from "../middleware/verifyToken";
+import { serverError } from "../errors";
 
 const router = express.Router();
 
@@ -54,6 +59,57 @@ router.post("/signin", async (req, res) => {
   res.status(result.status).json(result);
 })
 
+router.get("/kakao", async (req, res) => {
+  try{
+  const REST_API_KEY = config.kakaoRestAPIKey;
+  const REDIRECT_URI = config.redirectUri;
+  const kakaoAuthUrl = `https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=${REST_API_KEY}&redirect_uri=${REDIRECT_URI}`;
+  res.redirect(kakaoAuthUrl);
+  } catch (err) {
+    console.log(err);
+    return serverError;
+  }
+})
+
+router.get("/kakao/callback", async (req, res) => {
+  try{
+    //토큰 유효성 검사
+    const token = await axios({
+      method: "POST",
+      url: "https://kauth.kakao.com/oauth/token",
+      headers:{
+        'content-type':'application/x-www-form-urlencoded'
+      },
+      data:qs.stringify({
+        grant_type: 'authorization_code',
+        client_id: config.kakaoRestAPIKey,
+        redirectUri: config.redirectUri,
+        code: req.query.code,
+      })
+    });
+
+  } catch (err) {
+    console.log(err);
+    return serverError;
+  }
+  const result = await authService.kakao();
+  res.status(result.status).json(result);
+})
+
+
+router.post("/nickname", async (req, res) => {
+  try{
+    const nickname = req.body.nickname;
+    const requestDTO: KakaoRequestDTO = {
+      nickname: nickname
+    };
+    const result = await authService.nickname(requestDTO);
+    res.status(result.status).json(result);
+  } catch (err) {
+    console.log(err);
+    return serverError;
+  }
+})
 
 module.exports = router;
 

--- a/src/api/docs/auth.ts
+++ b/src/api/docs/auth.ts
@@ -1,0 +1,66 @@
+/**
+ * @api {get} /api/kakao 카카오 로그인
+ * 
+ * @apiVersion 1.0.0
+ * @apiName kakaoLogin
+ * @apiGroup 로그인/회원가입
+ *
+ * @apiSuccess {String} message
+ * 
+ * @apiSuccessExample {json} Success-Response:
+ * 200 OK
+ * {
+ *  "status": 200,
+ *  "message": "토큰 인증을 완료하였습니다."
+ * }
+ * 
+ * 500 서버 에러
+ * {
+ *  "status": 500,
+ *  "message": "서버 에러입니다. 서버 파트에게 문의해주세요 *^^*"
+ * }
+ */
+
+/**
+ * @api {post} /api/nickname 소셜로그인 회원가입
+ * 
+ * @apiVersion 1.0.0
+ * @apiName createUser
+ * @apiGroup 로그인/회원가입
+ * 
+ * @apiParamExample {json} Request-Example:
+ * {
+ *  "nickname": "시원뿡"
+ * }
+ *
+ * @apiSuccess {string} jwt
+ * 
+ * @apiSuccessExample {json} Success-Response:
+ * 200 OK
+ * {
+ *  "status": 200,
+ *  "data": {
+ *    "jwt": "jwt 토큰"
+ *  }
+ * }
+ * 
+ * @apiErrorExample Error-Response:
+ * 
+ * 404 닉네임 글자 제한
+ * {
+ *  "status": 404,
+ *  "message": "닉네임은 1-6글자 이내로 작성해주세요"
+ * }
+ * 
+ * 404 닉네임 중복
+ * {
+ *  "status": 404,
+ *  "message": "이미 사용 중인 닉네임입니다."
+ * }
+ * 
+ * 500 서버 에러
+ * {
+ *  "status": 500,
+ *  "message": "서버 에러입니다. 서버 파트에게 문의해주세요 *^^*"
+ * }
+ */

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -40,5 +40,11 @@ export default {
    * Your secret sauce
    */
   firebaseID: process.env.FIREBASE_ID,
-  firebaseDB: process.env.FIREBASE_DB
+  firebaseDB: process.env.FIREBASE_DB,
+
+  /**
+   * Your secret sauce
+   */
+  kakaoRestAPIKey: process.env.REST_API_KEY,
+  redirectUri: process.env.REDIRECT_URI,
 };

--- a/src/dto/Auth/Kakao/request/KakaoRequestDTO.ts
+++ b/src/dto/Auth/Kakao/request/KakaoRequestDTO.ts
@@ -1,0 +1,3 @@
+export interface KakaoRequestDTO {
+	nickname: string;
+}

--- a/src/dto/Auth/Kakao/response/KakaoResponseDTO.ts
+++ b/src/dto/Auth/Kakao/response/KakaoResponseDTO.ts
@@ -1,0 +1,4 @@
+export interface KakaoResponseDTO {
+	status: number;
+  message: string;
+}

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -3,10 +3,10 @@ import sequelize from './index';
 
 interface UserAttributes {
   id?: number; //not null, auto increment
-  uid: string;
+  uid?: string;
   token?: string;
-  email : string;
-  password: string;
+  email?: string;
+  password?: string;
   nickname: string;
   affinity?: number;
   level?: number;
@@ -33,10 +33,10 @@ interface UserAttributes {
 
 export class User extends Model<UserAttributes>{
   public readonly id!: number;
-  public uid!: string;
+  public uid: string;
   public token: string;
-  public email!: string;
-  public password!: string;
+  public email: string;
+  public password: string;
   public nickname!: string;
   public affinity: number;
   public level: number;
@@ -68,23 +68,18 @@ User.init(
   {
     uid: {
       type: DataTypes.STRING(100),
-        allowNull: false,
-        unique: true,
     },
     token: {
       type: DataTypes.STRING(100),
     },
     email: {
       type: DataTypes.STRING(30),
-      allowNull: false,
-      unique:true,
       validate: {
         isEmail: true,
       }
     },
     password: {
       type: DataTypes.STRING(20),
-      allowNull: false,
     },
     nickname: {
       type: DataTypes.STRING(10),


### PR DESCRIPTION
## 카카오 로그인 API
1. DB에 uid랑 email unique값 해제해줬습니다!
uid는 파이어베이스에서 가져오는건데... 파이어베이스에다가 사용자를 담아둘 필요가 없었던 것 같아요ㅠ 이거는 곧 삭제할 계획입니다!!
소셜 로그인으로 회원가입하면 이메일,패스워드 둘 다 받지 않고 닉네임만 생기는거라 email에 null값이 들어가는데 unique 설정을 하면 null이 또 들어갈 수 없어서 해제했습니다 ~

2. email, password allowNull: true
위에 말씀드린대로 소셜로그인은 이메일, 패스워드 받지 않아서 해제했습니다 !

3. 카카오 로그인 플로우
서버에서 토큰 유효성 검사를 해주면 클라이언트가 응답 받고 닉네임 설정 페이지로 넘어갑니다! 닉네임 설정해서 서버한테 넘겨주면 그 닉네임으로 유저 생성하는 방향으로 만들었습니다!
오늘 승찬오빠랑 주예랑 이야기해서 이렇게 만들었는데 바뀔 수도 잇을 것 같아요 !!

## 테스트
![image](https://user-images.githubusercontent.com/71828832/136205259-169e6450-964d-4c69-b313-a8321345373e.png)
주소창에 localhost:5000/api/kakao를 입력하면 이런 화면이 뜹니다! 아이디랑 비밀번호 입력하면 다음 화면이 등장합니다 !!

![image](https://user-images.githubusercontent.com/71828832/136205379-72fe3db0-98d5-40aa-aa51-e2c99bb645c8.png)
포스트맨으로는 확인하기 어려워서 웹으로 햇어요 !!

![image](https://user-images.githubusercontent.com/71828832/136205439-81fc7b69-fea6-4d02-8451-0ed4a4b0cbae.png)
그 다음에 닉네임 설정해주면 jwt 주면서 user 새로 생성합니다!

