### PR TITLE
[Home] 홈 조회 API

### DIFF
--- a/apidoc/api_data.js
+++ b/apidoc/api_data.js
@@ -1694,5 +1694,102 @@ define({ "api": [
     },
     "filename": "src/api/docs/profile.ts",
     "groupTitle": "프로필"
+  },
+  {
+    "type": "get",
+    "url": "/api/home",
+    "title": "홈 조회",
+    "version": "1.0.0",
+    "name": "Home",
+    "group": "홈",
+    "header": {
+      "examples": [
+        {
+          "title": "Header-Example:",
+          "content": "{\n \"Content-Type\": \"application/json\",\n \"Bearer\": \"{jwt}\"\n}",
+          "type": "json"
+        }
+      ]
+    },
+    "success": {
+      "fields": {
+        "Success 200": [
+          {
+            "group": "Success 200",
+            "type": "String",
+            "optional": false,
+            "field": "nickname",
+            "description": "<p>유저 닉네임</p>"
+          },
+          {
+            "group": "Success 200",
+            "type": "Number",
+            "optional": false,
+            "field": "level",
+            "description": "<p>유저 레벨</p>"
+          },
+          {
+            "group": "Success 200",
+            "type": "Number",
+            "optional": false,
+            "field": "happy",
+            "description": "<p>현재 유저 해피 지수</p>"
+          },
+          {
+            "group": "Success 200",
+            "type": "Number",
+            "optional": false,
+            "field": "fullHappy",
+            "description": "<p>현재 레벨에서 채워야 할 max 해피지수</p>"
+          },
+          {
+            "group": "Success 200",
+            "type": "String",
+            "optional": false,
+            "field": "characterSkin",
+            "description": "<p>유저 캐릭터 스킨 이미지 url</p>"
+          },
+          {
+            "group": "Success 200",
+            "type": "Boolean",
+            "optional": false,
+            "field": "isNew",
+            "description": "<p>새로운 스타일을 받았는지 여부</p>"
+          },
+          {
+            "group": "Success 200",
+            "type": "String",
+            "optional": false,
+            "field": "challengeTitle",
+            "description": "<p>현재 진행하고 있는 챌린지 제목</p>"
+          },
+          {
+            "group": "Success 200",
+            "type": "Number",
+            "optional": false,
+            "field": "percent",
+            "description": "<p>코스 진행 현황 퍼센트</p>"
+          }
+        ]
+      },
+      "examples": [
+        {
+          "title": "Success-Response:",
+          "content": "200 코스 진행 전\n{\n \"status\": 200,\n \"data\": {\n   \"nicknema\": \"모행\",\n   \"level\": 15,\n   \"happy\": 24,\n   \"fullHappy\": 90,\n   \"characterSkin\": \"image.url\",\n   \"isNew\": false,\n   course: {},\n }\n}\n\n200 코스 진행 중\n{\n \"status\": 200,\n \"data\": {\n   \"nicknema\": \"모행\",\n   \"level\": 15,\n   \"happy\": 24,\n   \"fullHappy\": 90,\n   \"characterSkin\": \"image.url\",\n   \"isNew\": false,\n   course: {\n     \"challengeTitle\": \"하늘 사진 찍기\",\n     \"percent\": 14,\n   },\n }\n}",
+          "type": "json"
+        }
+      ]
+    },
+    "error": {
+      "examples": [
+        {
+          "title": "Error-Response:",
+          "content": "401 존재하지 않는 유저\n{\n \"status\": 401,\n \"message\": \"유저가 존재하지 않습니다.\"\n}",
+          "type": "json"
+        }
+      ]
+    },
+    "filename": "src/api/docs/home.ts",
+    "groupTitle": "홈"
   }
 ] });

--- a/apidoc/api_data.js
+++ b/apidoc/api_data.js
@@ -1753,8 +1753,15 @@ define({ "api": [
             "group": "Success 200",
             "type": "Boolean",
             "optional": false,
-            "field": "isNew",
+            "field": "isStyleNew",
             "description": "<p>새로운 스타일을 받았는지 여부</p>"
+          },
+          {
+            "group": "Success 200",
+            "type": "Boolean",
+            "optional": false,
+            "field": "isBadgeNew",
+            "description": "<p>새로운 뱃지를 받았는지 여부</p>"
           },
           {
             "group": "Success 200",
@@ -1775,7 +1782,7 @@ define({ "api": [
       "examples": [
         {
           "title": "Success-Response:",
-          "content": "200 코스 진행 전\n{\n \"status\": 200,\n \"data\": {\n   \"nicknema\": \"모행\",\n   \"level\": 15,\n   \"happy\": 24,\n   \"fullHappy\": 90,\n   \"characterSkin\": \"image.url\",\n   \"isNew\": false,\n   course: {},\n }\n}\n\n200 코스 진행 중\n{\n \"status\": 200,\n \"data\": {\n   \"nicknema\": \"모행\",\n   \"level\": 15,\n   \"happy\": 24,\n   \"fullHappy\": 90,\n   \"characterSkin\": \"image.url\",\n   \"isNew\": false,\n   course: {\n     \"challengeTitle\": \"하늘 사진 찍기\",\n     \"percent\": 14,\n   },\n }\n}",
+          "content": "200 코스 진행 전\n{\n \"status\": 200,\n \"data\": {\n   \"nicknema\": \"모행\",\n   \"level\": 15,\n   \"happy\": 24,\n   \"fullHappy\": 90,\n   \"characterSkin\": \"image.url\",\n   \"isStyleNew\": false,\n   \"isBadgeNew\": false,\n   course: {},\n }\n}\n\n200 코스 진행 중\n{\n \"status\": 200,\n \"data\": {\n   \"nicknema\": \"모행\",\n   \"level\": 15,\n   \"happy\": 24,\n   \"fullHappy\": 90,\n   \"characterSkin\": \"image.url\",\n   \"isStyleNew\": false,\n   \"isBadgeNew\": false,\n   course: {\n     \"challengeTitle\": \"하늘 사진 찍기\",\n     \"percent\": 14,\n   },\n }\n}",
           "type": "json"
         }
       ]

--- a/apidoc/api_data.json
+++ b/apidoc/api_data.json
@@ -1753,8 +1753,15 @@
             "group": "Success 200",
             "type": "Boolean",
             "optional": false,
-            "field": "isNew",
+            "field": "isStyleNew",
             "description": "<p>새로운 스타일을 받았는지 여부</p>"
+          },
+          {
+            "group": "Success 200",
+            "type": "Boolean",
+            "optional": false,
+            "field": "isBadgeNew",
+            "description": "<p>새로운 뱃지를 받았는지 여부</p>"
           },
           {
             "group": "Success 200",
@@ -1775,7 +1782,7 @@
       "examples": [
         {
           "title": "Success-Response:",
-          "content": "200 코스 진행 전\n{\n \"status\": 200,\n \"data\": {\n   \"nicknema\": \"모행\",\n   \"level\": 15,\n   \"happy\": 24,\n   \"fullHappy\": 90,\n   \"characterSkin\": \"image.url\",\n   \"isNew\": false,\n   course: {},\n }\n}\n\n200 코스 진행 중\n{\n \"status\": 200,\n \"data\": {\n   \"nicknema\": \"모행\",\n   \"level\": 15,\n   \"happy\": 24,\n   \"fullHappy\": 90,\n   \"characterSkin\": \"image.url\",\n   \"isNew\": false,\n   course: {\n     \"challengeTitle\": \"하늘 사진 찍기\",\n     \"percent\": 14,\n   },\n }\n}",
+          "content": "200 코스 진행 전\n{\n \"status\": 200,\n \"data\": {\n   \"nicknema\": \"모행\",\n   \"level\": 15,\n   \"happy\": 24,\n   \"fullHappy\": 90,\n   \"characterSkin\": \"image.url\",\n   \"isStyleNew\": false,\n   \"isBadgeNew\": false,\n   course: {},\n }\n}\n\n200 코스 진행 중\n{\n \"status\": 200,\n \"data\": {\n   \"nicknema\": \"모행\",\n   \"level\": 15,\n   \"happy\": 24,\n   \"fullHappy\": 90,\n   \"characterSkin\": \"image.url\",\n   \"isStyleNew\": false,\n   \"isBadgeNew\": false,\n   course: {\n     \"challengeTitle\": \"하늘 사진 찍기\",\n     \"percent\": 14,\n   },\n }\n}",
           "type": "json"
         }
       ]

--- a/apidoc/api_data.json
+++ b/apidoc/api_data.json
@@ -1694,5 +1694,102 @@
     },
     "filename": "src/api/docs/profile.ts",
     "groupTitle": "프로필"
+  },
+  {
+    "type": "get",
+    "url": "/api/home",
+    "title": "홈 조회",
+    "version": "1.0.0",
+    "name": "Home",
+    "group": "홈",
+    "header": {
+      "examples": [
+        {
+          "title": "Header-Example:",
+          "content": "{\n \"Content-Type\": \"application/json\",\n \"Bearer\": \"{jwt}\"\n}",
+          "type": "json"
+        }
+      ]
+    },
+    "success": {
+      "fields": {
+        "Success 200": [
+          {
+            "group": "Success 200",
+            "type": "String",
+            "optional": false,
+            "field": "nickname",
+            "description": "<p>유저 닉네임</p>"
+          },
+          {
+            "group": "Success 200",
+            "type": "Number",
+            "optional": false,
+            "field": "level",
+            "description": "<p>유저 레벨</p>"
+          },
+          {
+            "group": "Success 200",
+            "type": "Number",
+            "optional": false,
+            "field": "happy",
+            "description": "<p>현재 유저 해피 지수</p>"
+          },
+          {
+            "group": "Success 200",
+            "type": "Number",
+            "optional": false,
+            "field": "fullHappy",
+            "description": "<p>현재 레벨에서 채워야 할 max 해피지수</p>"
+          },
+          {
+            "group": "Success 200",
+            "type": "String",
+            "optional": false,
+            "field": "characterSkin",
+            "description": "<p>유저 캐릭터 스킨 이미지 url</p>"
+          },
+          {
+            "group": "Success 200",
+            "type": "Boolean",
+            "optional": false,
+            "field": "isNew",
+            "description": "<p>새로운 스타일을 받았는지 여부</p>"
+          },
+          {
+            "group": "Success 200",
+            "type": "String",
+            "optional": false,
+            "field": "challengeTitle",
+            "description": "<p>현재 진행하고 있는 챌린지 제목</p>"
+          },
+          {
+            "group": "Success 200",
+            "type": "Number",
+            "optional": false,
+            "field": "percent",
+            "description": "<p>코스 진행 현황 퍼센트</p>"
+          }
+        ]
+      },
+      "examples": [
+        {
+          "title": "Success-Response:",
+          "content": "200 코스 진행 전\n{\n \"status\": 200,\n \"data\": {\n   \"nicknema\": \"모행\",\n   \"level\": 15,\n   \"happy\": 24,\n   \"fullHappy\": 90,\n   \"characterSkin\": \"image.url\",\n   \"isNew\": false,\n   course: {},\n }\n}\n\n200 코스 진행 중\n{\n \"status\": 200,\n \"data\": {\n   \"nicknema\": \"모행\",\n   \"level\": 15,\n   \"happy\": 24,\n   \"fullHappy\": 90,\n   \"characterSkin\": \"image.url\",\n   \"isNew\": false,\n   course: {\n     \"challengeTitle\": \"하늘 사진 찍기\",\n     \"percent\": 14,\n   },\n }\n}",
+          "type": "json"
+        }
+      ]
+    },
+    "error": {
+      "examples": [
+        {
+          "title": "Error-Response:",
+          "content": "401 존재하지 않는 유저\n{\n \"status\": 401,\n \"message\": \"유저가 존재하지 않습니다.\"\n}",
+          "type": "json"
+        }
+      ]
+    },
+    "filename": "src/api/docs/home.ts",
+    "groupTitle": "홈"
   }
 ]

--- a/apidoc/api_project.js
+++ b/apidoc/api_project.js
@@ -9,7 +9,7 @@ define({
   "apidoc": "0.3.0",
   "generator": {
     "name": "apidoc",
-    "time": "2021-10-10T05:18:12.359Z",
+    "time": "2021-10-10T05:55:36.311Z",
     "url": "https://apidocjs.com",
     "version": "0.28.1"
   }

--- a/apidoc/api_project.js
+++ b/apidoc/api_project.js
@@ -9,8 +9,8 @@ define({
   "apidoc": "0.3.0",
   "generator": {
     "name": "apidoc",
-    "time": "2021-10-09T14:12:13.160Z",
+    "time": "2021-10-10T05:18:12.359Z",
     "url": "https://apidocjs.com",
-    "version": "0.29.0"
+    "version": "0.28.1"
   }
 });

--- a/apidoc/api_project.json
+++ b/apidoc/api_project.json
@@ -9,7 +9,7 @@
   "apidoc": "0.3.0",
   "generator": {
     "name": "apidoc",
-    "time": "2021-10-10T05:18:12.359Z",
+    "time": "2021-10-10T05:55:36.311Z",
     "url": "https://apidocjs.com",
     "version": "0.28.1"
   }

--- a/apidoc/api_project.json
+++ b/apidoc/api_project.json
@@ -9,8 +9,8 @@
   "apidoc": "0.3.0",
   "generator": {
     "name": "apidoc",
-    "time": "2021-10-09T14:12:13.160Z",
+    "time": "2021-10-10T05:18:12.359Z",
     "url": "https://apidocjs.com",
-    "version": "0.29.0"
+    "version": "0.28.1"
   }
 }

--- a/src/api/docs/home.ts
+++ b/src/api/docs/home.ts
@@ -16,7 +16,8 @@
  * @apiSuccess {Number} happy 현재 유저 해피 지수
  * @apiSuccess {Number} fullHappy 현재 레벨에서 채워야 할 max 해피지수
  * @apiSuccess {String} characterSkin 유저 캐릭터 스킨 이미지 url
- * @apiSuccess {Boolean} isNew 새로운 스타일을 받았는지 여부
+ * @apiSuccess {Boolean} isStyleNew 새로운 스타일을 받았는지 여부
+ * @apiSuccess {Boolean} isBadgeNew 새로운 뱃지를 받았는지 여부
  * @apiSuccess {String} challengeTitle 현재 진행하고 있는 챌린지 제목
  * @apiSuccess {Number} percent 코스 진행 현황 퍼센트
  * 
@@ -30,7 +31,8 @@
  *    "happy": 24,
  *    "fullHappy": 90,
  *    "characterSkin": "image.url",
- *    "isNew": false,
+ *    "isStyleNew": false,
+ *    "isBadgeNew": false,
  *    course: {},
  *  }
  * }
@@ -44,7 +46,8 @@
  *    "happy": 24,
  *    "fullHappy": 90,
  *    "characterSkin": "image.url",
- *    "isNew": false,
+ *    "isStyleNew": false,
+ *    "isBadgeNew": false,
  *    course: {
  *      "challengeTitle": "하늘 사진 찍기",
  *      "percent": 14,

--- a/src/api/docs/home.ts
+++ b/src/api/docs/home.ts
@@ -1,0 +1,61 @@
+/**
+ * @api {get} /api/home 홈 조회
+ * 
+ * @apiVersion 1.0.0
+ * @apiName Home
+ * @apiGroup 홈
+ * 
+ * @apiHeaderExample {json} Header-Example:
+ * {
+ *  "Content-Type": "application/json",
+ *  "Bearer": "{jwt}"
+ * }
+ * 
+ * @apiSuccess {String} nickname 유저 닉네임
+ * @apiSuccess {Number} level 유저 레벨
+ * @apiSuccess {Number} happy 현재 유저 해피 지수
+ * @apiSuccess {Number} fullHappy 현재 레벨에서 채워야 할 max 해피지수
+ * @apiSuccess {String} characterSkin 유저 캐릭터 스킨 이미지 url
+ * @apiSuccess {Boolean} isNew 새로운 스타일을 받았는지 여부
+ * @apiSuccess {String} challengeTitle 현재 진행하고 있는 챌린지 제목
+ * @apiSuccess {Number} percent 코스 진행 현황 퍼센트
+ * 
+ * @apiSuccessExample {json} Success-Response:
+ * 200 코스 진행 전
+ * {
+ *  "status": 200,
+ *  "data": {
+ *    "nicknema": "모행",
+ *    "level": 15,
+ *    "happy": 24,
+ *    "fullHappy": 90,
+ *    "characterSkin": "image.url",
+ *    "isNew": false,
+ *    course: {},
+ *  }
+ * }
+ * 
+ * 200 코스 진행 중
+ * {
+ *  "status": 200,
+ *  "data": {
+ *    "nicknema": "모행",
+ *    "level": 15,
+ *    "happy": 24,
+ *    "fullHappy": 90,
+ *    "characterSkin": "image.url",
+ *    "isNew": false,
+ *    course: {
+ *      "challengeTitle": "하늘 사진 찍기",
+ *      "percent": 14,
+ *    },
+ *  }
+ * }
+ * 
+ * @apiErrorExample Error-Response:
+ * 401 존재하지 않는 유저
+ * {
+ *  "status": 401,
+ *  "message": "유저가 존재하지 않습니다."
+ * }
+ */

--- a/src/api/home.ts
+++ b/src/api/home.ts
@@ -1,0 +1,12 @@
+import express from "express";
+import auth from "../middleware/auth";
+import homeService from '../service/homeService';
+
+const router = express.Router();
+
+router.get("/", auth, async (req, res) => {
+  const result = await homeService.home(req.body.user.id);
+  res.status(result.status).json(result);
+});
+
+module.exports = router;

--- a/src/dto/Home/HomeResponseDTO.ts
+++ b/src/dto/Home/HomeResponseDTO.ts
@@ -1,0 +1,19 @@
+export default interface HomeResponseDTO {
+  status: number;
+  data: UserResponseDTO;
+}
+
+export interface UserResponseDTO {
+  nickname: string;
+  level: number;
+  happy: number;
+  fullHappy: number;
+  characterSkin: string;
+  isNew: boolean;
+  course: UserCourseResponseDTO;
+}
+
+export interface UserCourseResponseDTO {
+  challengeTitle?: string;
+  percent?: number;
+}

--- a/src/dto/Home/HomeResponseDTO.ts
+++ b/src/dto/Home/HomeResponseDTO.ts
@@ -9,7 +9,8 @@ export interface UserResponseDTO {
   happy: number;
   fullHappy: number;
   characterSkin: string;
-  isNew: boolean;
+  isStyleNew: boolean;
+  isBadgeNew: boolean;
   course: UserCourseResponseDTO;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,6 +56,7 @@ app.use("/api", require("./api/auth"));
 app.use("/api/today", require("./api/challenge"));
 app.use("/api/character", require("./api/character"));
 app.use("/api/badge", require("./api/badge"));
+app.use("/api/home", require("./api/home"));
 
 // error handler
 app.use(function (err, req, res, next) {

--- a/src/service/challengeService.ts
+++ b/src/service/challengeService.ts
@@ -282,6 +282,9 @@ export default {
             level: userLevel,
             styleImg: ""
           };
+        } else {
+          userHappy += challenge.getHappy();
+          happy += challenge.getHappy();
         }
       }
 
@@ -321,6 +324,9 @@ export default {
               level: userLevel,
               styleImg: ""
             };
+          } else {
+            userHappy += course.getHappy();
+            happy += course.getHappy();
           }
         }
 

--- a/src/service/homeService.ts
+++ b/src/service/homeService.ts
@@ -11,7 +11,7 @@ export default {
     try {
       // 닉네임, 레벨, 해피지수, 현재 코스, 현재 챌린지, 현재 코스 진행률, 캐릭터 스킨, 스타일 업데이트 여부
       const user = await User.findOne({
-        attributes: ['nickname', 'level', 'affinity', 'current_course_id', 'current_challenge_id', 'current_progress_percent', 'character_skin', 'is_style_new'],
+        attributes: ['nickname', 'level', 'affinity', 'current_course_id', 'current_challenge_id', 'current_progress_percent', 'character_skin', 'is_style_new', 'is_badge_new'],
         where: { id: id }
       });
 
@@ -37,7 +37,8 @@ export default {
           happy: user.affinity,
           fullHappy: levels[user.level - 1].getFullHappy(),
           characterSkin: user.character_skin + ".url",
-          isNew: user.is_style_new,
+          isStyleNew: user.is_style_new,
+          isBadgeNew: user.is_badge_new,
           course: courseResponseDTO
         }
       };

--- a/src/service/homeService.ts
+++ b/src/service/homeService.ts
@@ -1,0 +1,55 @@
+import { SERVER_ERROR_MESSAGE } from '../constant';
+import { IFail } from "../interfaces/IFail";
+import { User } from '../models/User';
+import { notExistUser } from "../errors";
+import HomeResponseDTO, { UserCourseResponseDTO } from '../dto/Home/HomeResponseDTO';
+import { courses } from '../dummy/Course';
+import { levels } from '../dummy/Level';
+
+export default {
+  home: async (id: string) => {
+    try {
+      // 닉네임, 레벨, 해피지수, 현재 코스, 현재 챌린지, 현재 코스 진행률, 캐릭터 스킨, 스타일 업데이트 여부
+      const user = await User.findOne({
+        attributes: ['nickname', 'level', 'affinity', 'current_course_id', 'current_challenge_id', 'current_progress_percent', 'character_skin', 'is_style_new'],
+        where: { id: id }
+      });
+
+      if (!user) {
+        return notExistUser;
+      }
+
+      let courseResponseDTO: UserCourseResponseDTO = {};
+      if (user.current_course_id && user.current_challenge_id && user.current_progress_percent) {
+        const courseId = user.current_course_id - 1;
+        const challengeId = user.current_challenge_id - 1;
+        courseResponseDTO = {
+          challengeTitle: courses[courseId].getChallenges()[challengeId].getTitle(),
+          percent: user.current_progress_percent
+        };
+      }
+
+      const responseDTO: HomeResponseDTO = {
+        status: 200,
+        data: {
+          nickname: user.nickname,
+          level: user.level,
+          happy: user.affinity,
+          fullHappy: levels[user.level - 1].getFullHappy(),
+          characterSkin: user.character_skin + ".url",
+          isNew: user.is_style_new,
+          course: courseResponseDTO
+        }
+      };
+
+      return responseDTO;
+    } catch (err) {
+      console.error(err.message);
+      const serverError: IFail = {
+        status: 500,
+        message: SERVER_ERROR_MESSAGE,
+      };
+      return serverError;
+    }
+  }
+}


### PR DESCRIPTION
# 챌린지 부분도 변경
챌린지 인증할 때 레벨업할때만 해피지수를 주고있었어서.. 그거 바꾼것도 같이 반영했어요! 
(원래 이러면 안되는데 커밋을 해버려서.. 다음엔 따로 할게여!)

## 코스 진행 중일 때 응답
![스크린샷 2021-10-10 오후 2 10 33](https://user-images.githubusercontent.com/49138331/136683367-67cf85ed-aaa3-49ee-abfc-9890f9297325.png)

## 코스 진행 전일 때 응답
![스크린샷 2021-10-10 오후 2 09 44](https://user-images.githubusercontent.com/49138331/136683375-e8646ddf-d75a-4601-a38e-250ddea583d7.png)

## apidoc
![스크린샷 2021-10-10 오후 2 20 29](https://user-images.githubusercontent.com/49138331/136683377-eff2d1bb-93e3-409c-8523-6efd14630cff.png)

