### PR TITLE
[코스] 코스 진행/다시하기 시 유저 챌린지 진행 퍼센트

### DIFF
--- a/src/service/courseService.ts
+++ b/src/service/courseService.ts
@@ -213,6 +213,7 @@ export default {
         {
           current_course_id: cid+1,
           current_challenge_id: 1,
+          current_progress_percent: 0,
           is_completed: false,
           challenge_penalty: isPenalty,
         },


### PR DESCRIPTION
> 코스 진행하기/다시하기 시에 유저 진행 상황 퍼센트를 초기화 안해줘서 0으로 해주었습니당
db에 잘 적용되는거 확인 완료!