### PR TITLE
[챌린지] 챌린지 인증 시 연속 챌린지 체크 로직 수정

### DIFF
--- a/src/service/challengeService.ts
+++ b/src/service/challengeService.ts
@@ -417,11 +417,15 @@ export default {
       });
       
       const today = new Date(); // 오늘
-      let recentChallengeDate = new Date(); // DB에 저장된 최근 챌린지 완료 날짜 다음날
-      recentChallengeDate = new Date(recentChallengeDate.setDate(user.recent_challenge_date.getDate() + 1));
-      // 챌린지 연속 수행 여부
-      if (getYear(today) == getYear(recentChallengeDate) && getMonth(today) == getMonth(recentChallengeDate) && getDay(today) == getDay(recentChallengeDate)) { // 연속 수행에 성공한 경우
-        challengeSuccessCount++;
+      if (user.recent_challenge_date != null) {
+        let recentChallengeDate = new Date(); // DB에 저장된 최근 챌린지 완료 날짜 다음날
+        recentChallengeDate = new Date(recentChallengeDate.setDate(user.recent_challenge_date.getDate() + 1));
+        // 챌린지 연속 수행 여부
+        if (getYear(today) == getYear(recentChallengeDate) && getMonth(today) == getMonth(recentChallengeDate) && getDay(today) == getDay(recentChallengeDate)) { // 연속 수행에 성공한 경우
+          challengeSuccessCount++;
+        } else {
+          challengeSuccessCount = 1;
+        }
       } else {
         challengeSuccessCount = 1;
       }


### PR DESCRIPTION
> 연속 챌린지 체크 시 최근 챌린지 수행 날짜가 null이면 오류 발생 -> 로직에 null 체크 추가
아래 테스트는 최근 챌린지 수행 날짜가 null일 때 테스트한 것. 잘 동작합니다!

## 테스트
![image](https://user-images.githubusercontent.com/49138331/138129496-ca7a5e19-a91d-4940-bd59-3f8a7454bb6d.png)
