### PR TITLE
[애플로그인] 애플로그인 id 토큰 확인

### DIFF
--- a/apidoc/api_data.js
+++ b/apidoc/api_data.js
@@ -1,5 +1,62 @@
 define({ "api": [
   {
+    "type": "post",
+    "url": "/api/apple/login",
+    "title": "애플 로그인",
+    "version": "1.0.0",
+    "name": "appleLogIn",
+    "group": "로그인/회원가입",
+    "header": {
+      "examples": [
+        {
+          "title": "Header-Example:",
+          "content": "{\n \"Content-Type\": \"application/json\"\n \"idToken\": \"apple id token\"\n}",
+          "type": "json"
+        }
+      ]
+    },
+    "parameter": {
+      "examples": [
+        {
+          "title": "Request-Example:",
+          "content": "{\n \"token\": \"device token\"\n}",
+          "type": "json"
+        }
+      ]
+    },
+    "success": {
+      "fields": {
+        "Success 200": [
+          {
+            "group": "Success 200",
+            "type": "string",
+            "optional": false,
+            "field": "jwt",
+            "description": ""
+          }
+        ]
+      },
+      "examples": [
+        {
+          "title": "Success-Response:",
+          "content": "200 OK\n{\n \"status\": 200,\n \"data\": {\n   \"jwt\": \"jwt 토큰\"\n }\n}",
+          "type": "json"
+        }
+      ]
+    },
+    "error": {
+      "examples": [
+        {
+          "title": "Error-Response:",
+          "content": "\n403 토큰 누락\n{\n \"status\": 403,\n \"message\": \"토큰이 없습니다. 토큰을 함께 보내주세요.\"\n}\n\n403 토큰 유효성 검증 실패\n{\n \"status\": 403,\n \"message\": \"유효성 인증에 실패하였습니다.\"\n}\n\n500 서버 에러\n{\n \"status\": 500,\n \"message\": \"서버 에러입니다. 서버 파트에게 문의해주세요 *^^*\"\n}",
+          "type": "json"
+        }
+      ]
+    },
+    "filename": "src/api/docs/auth.ts",
+    "groupTitle": "로그인/회원가입"
+  },
+  {
     "type": "put",
     "url": "/api/password",
     "title": "비밀번호 변경",
@@ -58,16 +115,16 @@ define({ "api": [
   },
   {
     "type": "post",
-    "url": "/api/nickname",
-    "title": "소셜로그인 회원가입",
+    "url": "/api/apple",
+    "title": "애플 회원가입",
     "version": "1.0.0",
-    "name": "createUser",
+    "name": "createApple",
     "group": "로그인/회원가입",
     "header": {
       "examples": [
         {
           "title": "Header-Example:",
-          "content": "{\n \"Content-Type\": \"application/json\"\n \"token\": \"token\"\n}",
+          "content": "{\n \"Content-Type\": \"application/json\"\n \"idToken\": \"apple id token\"\n}",
           "type": "json"
         }
       ]
@@ -76,7 +133,7 @@ define({ "api": [
       "examples": [
         {
           "title": "Request-Example:",
-          "content": "{\n \"nickname\": \"시원뿡\"\n}",
+          "content": "{\n \"nickname\": \"시원뿡\"\n \"token\": \"device token\"\n}",
           "type": "json"
         }
       ]

--- a/apidoc/api_data.json
+++ b/apidoc/api_data.json
@@ -1,5 +1,62 @@
 [
   {
+    "type": "post",
+    "url": "/api/apple/login",
+    "title": "애플 로그인",
+    "version": "1.0.0",
+    "name": "appleLogIn",
+    "group": "로그인/회원가입",
+    "header": {
+      "examples": [
+        {
+          "title": "Header-Example:",
+          "content": "{\n \"Content-Type\": \"application/json\"\n \"idToken\": \"apple id token\"\n}",
+          "type": "json"
+        }
+      ]
+    },
+    "parameter": {
+      "examples": [
+        {
+          "title": "Request-Example:",
+          "content": "{\n \"token\": \"device token\"\n}",
+          "type": "json"
+        }
+      ]
+    },
+    "success": {
+      "fields": {
+        "Success 200": [
+          {
+            "group": "Success 200",
+            "type": "string",
+            "optional": false,
+            "field": "jwt",
+            "description": ""
+          }
+        ]
+      },
+      "examples": [
+        {
+          "title": "Success-Response:",
+          "content": "200 OK\n{\n \"status\": 200,\n \"data\": {\n   \"jwt\": \"jwt 토큰\"\n }\n}",
+          "type": "json"
+        }
+      ]
+    },
+    "error": {
+      "examples": [
+        {
+          "title": "Error-Response:",
+          "content": "\n403 토큰 누락\n{\n \"status\": 403,\n \"message\": \"토큰이 없습니다. 토큰을 함께 보내주세요.\"\n}\n\n403 토큰 유효성 검증 실패\n{\n \"status\": 403,\n \"message\": \"유효성 인증에 실패하였습니다.\"\n}\n\n500 서버 에러\n{\n \"status\": 500,\n \"message\": \"서버 에러입니다. 서버 파트에게 문의해주세요 *^^*\"\n}",
+          "type": "json"
+        }
+      ]
+    },
+    "filename": "src/api/docs/auth.ts",
+    "groupTitle": "로그인/회원가입"
+  },
+  {
     "type": "put",
     "url": "/api/password",
     "title": "비밀번호 변경",
@@ -58,16 +115,16 @@
   },
   {
     "type": "post",
-    "url": "/api/nickname",
-    "title": "소셜로그인 회원가입",
+    "url": "/api/apple",
+    "title": "애플 회원가입",
     "version": "1.0.0",
-    "name": "createUser",
+    "name": "createApple",
     "group": "로그인/회원가입",
     "header": {
       "examples": [
         {
           "title": "Header-Example:",
-          "content": "{\n \"Content-Type\": \"application/json\"\n \"token\": \"token\"\n}",
+          "content": "{\n \"Content-Type\": \"application/json\"\n \"idToken\": \"apple id token\"\n}",
           "type": "json"
         }
       ]
@@ -76,7 +133,7 @@
       "examples": [
         {
           "title": "Request-Example:",
-          "content": "{\n \"nickname\": \"시원뿡\"\n}",
+          "content": "{\n \"nickname\": \"시원뿡\"\n \"token\": \"device token\"\n}",
           "type": "json"
         }
       ]

--- a/apidoc/api_project.js
+++ b/apidoc/api_project.js
@@ -9,7 +9,7 @@ define({
   "apidoc": "0.3.0",
   "generator": {
     "name": "apidoc",
-    "time": "2021-10-20T16:11:52.107Z",
+    "time": "2021-10-22T08:31:59.523Z",
     "url": "https://apidocjs.com",
     "version": "0.29.0"
   }

--- a/apidoc/api_project.json
+++ b/apidoc/api_project.json
@@ -9,7 +9,7 @@
   "apidoc": "0.3.0",
   "generator": {
     "name": "apidoc",
-    "time": "2021-10-20T16:11:52.107Z",
+    "time": "2021-10-22T08:31:59.523Z",
     "url": "https://apidocjs.com",
     "version": "0.29.0"
   }

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "multer": "^1.4.3",
     "multer-s3": "^2.9.0",
     "mysql2": "^2.3.0",
+    "node-rsa": "^1.1.1",
     "node-schedule": "^2.0.0",
     "nodemailer": "^6.7.0",
     "nodemon": "^2.0.12",

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,16 +1,14 @@
 import express from "express";
-import axios from "axios";
-import qs from "qs";
 import { check, validationResult } from "express-validator";
-import config from "../config";
 import authService from "../service/authService";
 import { SignUpRequestDTO } from "../dto/Auth/SignUp/request/SignUpRequestDTO";
 import { SignInRequestDTO } from "../dto/Auth/SignIn/request/SignInRequestDTO";
+import { SocialSignUpRequestDTO } from "../dto/Auth/Social/request/SocialSignUpRequestDTO";
 import { SocialLogInRequestDTO } from "../dto/Auth/Social/request/SocialLogInRequestDTO";
 import { CheckEmailRequestDTO } from "../dto/Auth/Password/request/CheckEmailRequestDTO";
 import { ChangePasswordRequestDTO } from "../dto/Auth/Password/request/ChangePasswordRequestDTO";
 import auth from "../middleware/auth";
-import verifyFCM from "../middleware/verifyToken";
+import apple from "../middleware/apple";
 import { serverError } from "../errors";
 import kakao from "../middleware/kakao";
 
@@ -98,14 +96,30 @@ router.put(
     res.status(result.status).json(result);
   });
 
-router.post("/nickname", async (req, res) => {
+router.post("/apple", apple, async (req, res) => { 
   try{
-    const { nickname, token } = req.body;
-    const requestDTO: SocialLogInRequestDTO = {
+    const { nickname, sub, token } = req.body;
+    const requestDTO: SocialSignUpRequestDTO = {
       nickname: nickname,
+      sub: sub,
       token: token
     };
-    const result = await authService.nickname(requestDTO);
+    const result = await authService.social(requestDTO);
+    res.status(result.status).json(result);
+  } catch (err) {
+    console.log(err);
+    return serverError;
+  }
+})
+
+router.post("/apple/login", apple, async (req, res) => { 
+  try{
+    const { sub, token } = req.body;
+    const requestDTO: SocialLogInRequestDTO = {
+      sub: sub,
+      token: token
+    };
+    const result = await authService.socialLogIn(requestDTO);
     res.status(result.status).json(result);
   } catch (err) {
     console.log(err);
@@ -132,6 +146,8 @@ router.post("/kakao", kakao, async (req, res) => {
     return serverError;
   }
 })
+
+
 
 module.exports = router;
 

--- a/src/api/docs/auth.ts
+++ b/src/api/docs/auth.ts
@@ -158,21 +158,22 @@
  */
 
 /**
- * @api {post} /api/nickname 소셜로그인 회원가입
+ * @api {post} /api/apple 애플 회원가입
  * 
  * @apiVersion 1.0.0
- * @apiName createUser
+ * @apiName createApple
  * @apiGroup 로그인/회원가입
  * 
  * * @apiHeaderExample {json} Header-Example:
  * {
  *  "Content-Type": "application/json"
- *  "token": "token"
+ *  "idToken": "apple id token"
  * }
  * 
  * @apiParamExample {json} Request-Example:
  * {
  *  "nickname": "시원뿡"
+ *  "token": "device token"
  * }
  *
  * @apiSuccess {string} jwt
@@ -199,6 +200,56 @@
  *  "status": 404,
  *  "message": "이미 사용 중인 닉네임입니다."
  * }
+ * 
+ * 403 토큰 누락
+ * {
+ *  "status": 403,
+ *  "message": "토큰이 없습니다. 토큰을 함께 보내주세요."
+ * }
+ * 
+ * 403 토큰 유효성 검증 실패
+ * {
+ *  "status": 403,
+ *  "message": "유효성 인증에 실패하였습니다."
+ * }
+ * 
+ * 500 서버 에러
+ * {
+ *  "status": 500,
+ *  "message": "서버 에러입니다. 서버 파트에게 문의해주세요 *^^*"
+ * }
+ */
+
+/**
+ * @api {post} /api/apple/login 애플 로그인
+ * 
+ * @apiVersion 1.0.0
+ * @apiName appleLogIn
+ * @apiGroup 로그인/회원가입
+ * 
+ * * @apiHeaderExample {json} Header-Example:
+ * {
+ *  "Content-Type": "application/json"
+ *  "idToken": "apple id token"
+ * }
+ * 
+ * @apiParamExample {json} Request-Example:
+ * {
+ *  "token": "device token"
+ * }
+ *
+ * @apiSuccess {string} jwt
+ * 
+ * @apiSuccessExample {json} Success-Response:
+ * 200 OK
+ * {
+ *  "status": 200,
+ *  "data": {
+ *    "jwt": "jwt 토큰"
+ *  }
+ * }
+ * 
+ * @apiErrorExample Error-Response:
  * 
  * 403 토큰 누락
  * {

--- a/src/dto/Auth/Social/request/SocialLogInRequestDTO.ts
+++ b/src/dto/Auth/Social/request/SocialLogInRequestDTO.ts
@@ -1,4 +1,4 @@
 export interface SocialLogInRequestDTO {
-	nickname: string;
+	sub: string;
 	token: string;
 }

--- a/src/dto/Auth/Social/request/SocialSignUpRequestDTO.ts
+++ b/src/dto/Auth/Social/request/SocialSignUpRequestDTO.ts
@@ -1,0 +1,5 @@
+export interface SocialSignUpRequestDTO {
+	nickname: string;
+	sub: string;
+	token: string;
+}

--- a/src/middleware/apple.ts
+++ b/src/middleware/apple.ts
@@ -1,0 +1,43 @@
+import axios from "axios";
+import jwt from "jsonwebtoken";
+import { invalidToken, notExistToken, serverError } from "../errors";
+const NodeRSA = require('node-rsa');
+
+//Get public key
+export default async(req, res, next) => {
+  try{
+    const idToken = req.header("idToken");
+    if (!idToken) {
+      return notExistToken;
+    }
+    const result = await axios.request({
+      method: "GET",
+      url: "https://appleid.apple.com/auth/keys",
+    })
+    const key = result.data;
+    const jwtClaims = verifyIdToken(key, idToken);
+    jwtClaims
+    .then((token) => { 
+      const sub = token.sub
+      req.body.sub = sub;
+      next();
+    })
+    .catch((err) => {
+      console.log(err);
+      return invalidToken;
+    })
+  }
+  catch (err) {
+    console.log(err);
+    return serverError;
+  }
+};
+//Decryption of id'u token by public key and rs256 algorithm
+async function verifyIdToken(key, idToken) { //id_token, client_id
+    const keys = key.keys[0]
+    const publicKey = new NodeRSA();
+    publicKey.importKey({ n: Buffer.from(keys.n, 'base64'), e: Buffer.from(keys.e, 'base64') }, 'components-public');
+    const applePublicKey = publicKey.exportKey(['public'])
+    const jwtClaims = jwt.verify(idToken, applePublicKey, { algorithms: 'RS256' });
+    return jwtClaims;
+};

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -3,6 +3,7 @@ import sequelize from './index';
 
 interface UserAttributes {
   id?: number; //not null, auto increment
+  sub?: string;
   token?: string;
   email?: string;
   password?: string;
@@ -32,6 +33,7 @@ interface UserAttributes {
 
 export class User extends Model<UserAttributes>{
   public readonly id!: number;
+  public sub: string;
   public token: string;
   public email: string;
   public password: string;
@@ -64,6 +66,9 @@ export class User extends Model<UserAttributes>{
 
 User.init(
   {
+    sub: {
+      type: DataTypes.STRING(100),
+    },
     token: {
       type: DataTypes.STRING(100),
     },


### PR DESCRIPTION
## 애플 로그인/회원가입 완성
애플에서 id 토큰을 넘겨주면 여기서 제가 sub(subject)를 추출해옵니다!
sub은 식별자 역할을 해서 id 토큰이 바뀌어도 sub은 고정이라고 해요!
그래서 DB에 sub을 저장해놓고, 사용자가 로그인할 때  sub이 저장되어 있으면 이미 가입된 사용자로 판단해서 jwt 제공할 수 있을 것 같습니다 ~

아직 주예한테 슬랙 답장이 안왔는데 주예 답장에 따라서 코드가 변경 될 수 있을 것 같아요 ~

## 애플 회원가입
헤더
![image](https://user-images.githubusercontent.com/71828832/138422452-8029cc88-fd6a-4af6-ba31-4aeb10f8cf42.png)

바디
![image](https://user-images.githubusercontent.com/71828832/138422411-230efb21-b6c8-44ba-b5a6-6bf4764df56e.png)

## 애플 로그인
헤더
![image](https://user-images.githubusercontent.com/71828832/138422521-b89bb546-3b76-405e-82ca-192b25266db9.png)

바디
![image](https://user-images.githubusercontent.com/71828832/138422531-0af59369-e22f-4b56-ae9b-b24700b91de7.png)


