### PR TITLE
[챌린지] 챌린지 인증 시 특정 챌린지 뱃지 부여 로직 추가

### DIFF
--- a/src/service/challengeService.ts
+++ b/src/service/challengeService.ts
@@ -1,6 +1,6 @@
 import { SERVER_ERROR_MESSAGE } from "../constant";
 import { courses } from '../dummy/Course';
-import { challengeBadges, challengeCountBadges, courseBadges } from '../dummy/Badge';
+import { challengeBadges, challengeCountBadges, courseBadges, specificChallengeBadges } from '../dummy/Badge';
 import { levels } from '../dummy/Level';
 import { skins } from '../dummy/Skin';
 import { invalidCourseChallengeId, alreadyCompleteChallenge, notExistChallengeId, notExistCourseId, notExistProgressCourse, notExistUser } from "../errors";
@@ -500,6 +500,44 @@ export default {
           });
           badgeCount++;
         }
+      }
+
+      // 특정 챌린지 완료 뱃지
+      if (course_id == 9 && challenge_id == 1) {
+        isBadgeNew = true;
+        Badge.create({
+          id: specificChallengeBadges[0].getId(),
+          user_id: id
+        });
+        badgeCount++;
+      } else if (course_id == 7 && challenge_id == 1) {
+        isBadgeNew = true;
+        Badge.create({
+          id: specificChallengeBadges[1].getId(),
+          user_id: id
+        });
+        badgeCount++;
+      } else if (course_id == 11 && challenge_id == 1) {
+        isBadgeNew = true;
+        Badge.create({
+          id: specificChallengeBadges[2].getId(),
+          user_id: id
+        });
+        badgeCount++;
+      } else if (course_id == 14 && challenge_id == 7) {
+        isBadgeNew = true;
+        Badge.create({
+          id: specificChallengeBadges[3].getId(),
+          user_id: id
+        });
+        badgeCount++;
+      } else if (course_id == 1 && challenge_id == 6) {
+        isBadgeNew = true;
+        Badge.create({
+          id: specificChallengeBadges[4].getId(),
+          user_id: id
+        });
+        badgeCount++;
       }
 
       // 유저 정보 업데이트


### PR DESCRIPTION
> 특정 챌린지 완료 시 뱃지 부여하는 로직 추가했습니다.
뱃지 더미 업데이트됐습니다!

### response
![image](https://user-images.githubusercontent.com/49138331/138738908-248aa361-6d29-4862-a663-be30d53a753b.png)

### db
![image](https://user-images.githubusercontent.com/49138331/138738939-592e6e8d-ac79-43f7-8a62-e94dcb8ded38.png)
