### PR TITLE
[코스&챌린지] 더미 정렬 오류 수정

### DIFF
--- a/src/service/challengeService.ts
+++ b/src/service/challengeService.ts
@@ -52,6 +52,7 @@ export default {
         order: ['challenge_id']
       });
 
+      courses.sort((a, b) => (a.getId() < b.getId() ? -1 : 1));
       // 현재 진행 중인 코스
       const course = courses[courseId];
       // 현재 코스의 챌린지들
@@ -247,6 +248,7 @@ export default {
         return invalidCourseChallengeId;
       }
 
+      courses.sort((a, b) => (a.getId() < b.getId() ? -1 : 1));
       const course = courses[course_id - 1];  // 현재 코스
       const challenge = course.getChallenges()[challenge_id - 1]; // 현재 완료한 챌린지
 

--- a/src/service/courseService.ts
+++ b/src/service/courseService.ts
@@ -119,6 +119,7 @@ export default {
 
       let responseCourses: TotalCompleteCourseResponseDTO[] = [];
       let responseId = 1;
+      courses.sort((a, b) => (a.getId() < b.getId() ? -1 : 1));
 
       for (let i = 0; i < completeCourses.length; ++i) {
         let responseChallenges: TotalCompleteChallengeResponseDTO[] = [];
@@ -200,6 +201,7 @@ export default {
         return notExistCourseId;
       }
 
+      courses.sort((a, b) => (a.getId() < b.getId() ? -1 : 1));
       let challenges = courses[cid].getChallenges();
       let isPenalty = false;
       // 코스 변경인 경우


### PR DESCRIPTION
> 제목으로 정렬한 후에 코스 변경하면 오류가 생겨서 코스 더미 사용하는 부분에 아이디로 정렬하는 로직 추가해주었습니다!
테스팅도 완료~!